### PR TITLE
Sort modules.

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -27,7 +27,7 @@ handle("module") do data
 end
 
 handle("all-modules") do _
-  [string(m) for m in CodeTools.allchildren(Main)]
+  sort!([string(m) for m in CodeTools.allchildren(Main)])
 end
 
 isselection(data) = data["start"] ≠ data["end"]


### PR DESCRIPTION
Very minor change, but displaying the module dropdown in alphabetical order fits better with other dropdowns such as the language picker. Thoughts?