### PR TITLE
fix regexp in `splitlink` on Windows

### DIFF
--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -17,7 +17,7 @@ function btlines(bt, top_function::Symbol = :eval_user_input, set = 1:typemax(In
 end
 
 function splitlink(path)
-  m = match(r"(.*):(\d*)", path)
+  m = match(r"(.:?[^:]*)(?=:(\d*))?", path)
   (m == nothing || m.captures[2] == nothing) && return
   m.captures[1], parse(Int, m.captures[2])
 end

--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -17,7 +17,7 @@ function btlines(bt, top_function::Symbol = :eval_user_input, set = 1:typemax(In
 end
 
 function splitlink(path)
-  m = match(r"([^:]*)(?::(\d*))?", path)
+  m = match(r"(.*):(\d*)", path)
   (m == nothing || m.captures[2] == nothing) && return
   m.captures[1], parse(Int, m.captures[2])
 end


### PR DESCRIPTION
should fix https://github.com/JunoLab/atom-julia-client/issues/30, but I don't know if I break something with that naive regexp. Though it seems to work with linux-style paths as well as Windows style paths.