### PR TITLE
Have the Julia process be the server

### DIFF
--- a/src/comm.jl
+++ b/src/comm.jl
@@ -23,8 +23,9 @@ macro ierrs(ex)
     end)
 end
 
-function connect(port)
-  global sock = Base.connect(port)
+function startup(port)
+  server = listen(port)
+  global sock = Base.accept(server)
   @async while isopen(sock)
     @ierrs let # Don't let tasks close over the same t, data
       t, data = JSON.parse(sock)


### PR DESCRIPTION
Opens the possibility of multiple front-ends connect to the same Julia kernel. Relies on https://github.com/JunoLab/atom-julia-client/pull/58. 
