### PR TITLE
sticky errors

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -76,7 +76,8 @@ handle("eval-all") do data
       end
     catch e
       msg("error", @d(:msg => "Error evaluating $(basename(get(data, "path", "untitled")))",
-                      :detail => sprint(showerror, e, catch_backtrace())))
+                      :detail => sprint(showerror, e, catch_backtrace()),
+                      :dismissable => true))
     end
   end
   return


### PR DESCRIPTION
make error notifications sticky (must be closed by the user) when evaluating a file