### PR TITLE
julia-side support for copyable plaintext results

### DIFF
--- a/src/display/display.jl
+++ b/src/display/display.jl
@@ -4,6 +4,7 @@ import Media: render
 import Hiccup: div
 
 type Inline end
+type Plain end
 
 for D in :[Editor, Console].args
   @eval type $D end
@@ -65,6 +66,8 @@ render(e::Editor, ::Void; options = @d()) =
 
 render(::Editor, x; options = @d()) =
   render(Inline(), x, options = options)
+
+render(::Plain, x) = stringmime(MIME"text/plain"(), x)
 
 include("objects.jl")
 include("errors.jl")

--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -37,3 +37,14 @@ render(i::Inline, e::EvalError; options = @d()) =
      :view => render(i, Tree(rendererr(e.err),
                              [renderbt(btlines(e.bt))]), options = options),
      :highlights => highlights(e))
+
+function write_plain(io::IO, arg)
+  writemime(io, "text/plain", arg)
+  takebuf_string(plain_buffer)
+end
+
+function write_plain(io::IO, arg::EvalError)
+  println(io, sprint(showerror, arg.err))
+  [println(io, "in "*string(f)*" at "*loc) for (f, loc) in btlines(arg.bt)]
+  takebuf_string(io)
+end

--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -38,13 +38,10 @@ render(i::Inline, e::EvalError; options = @d()) =
                              [renderbt(btlines(e.bt))]), options = options),
      :highlights => highlights(e))
 
-function write_plain(io::IO, arg)
-  writemime(io, "text/plain", arg)
-  takebuf_string(plain_buffer)
-end
-
-function write_plain(io::IO, arg::EvalError)
-  println(io, sprint(showerror, arg.err))
-  [println(io, "in "*string(f)*" at "*loc) for (f, loc) in btlines(arg.bt)]
-  takebuf_string(io)
+function render(::Plain, x::EvalError)
+  str = sprint(showerror, x.err)
+  for (f, loc) in btlines(x.bt)
+    str *= "\nin "*string(f)*" at "*loc
+  end
+  str
 end

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -3,6 +3,8 @@ using CodeTools, LNR, Media
 import CodeTools: getblock, getthing
 import Requires: withpath
 
+const plain_buffer = IOBuffer()
+
 LNR.cursor(data::Associative) = cursor(data["row"], data["column"])
 
 function modulenames(data, pos)
@@ -58,7 +60,8 @@ handle("eval") do data
     end
     @d(:start => start,
        :end => stop,
-       :result => render(Editor(), result))
+       :result => render(Editor(), result),
+       :plainresult => write_plain(plain_buffer, result))
    end
 end
 

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -3,8 +3,6 @@ using CodeTools, LNR, Media
 import CodeTools: getblock, getthing
 import Requires: withpath
 
-const plain_buffer = IOBuffer()
-
 LNR.cursor(data::Associative) = cursor(data["row"], data["column"])
 
 function modulenames(data, pos)
@@ -61,7 +59,7 @@ handle("eval") do data
     @d(:start => start,
        :end => stop,
        :result => render(Editor(), result),
-       :plainresult => write_plain(plain_buffer, result))
+       :plainresult => render(Plain(), result))
    end
 end
 


### PR DESCRIPTION
So yeah, this not only sends the richly rendered results back to Atom, but some plaintext as well. The extra overhead is of course not desirable, but shouldn't be too bad.

I did try reconstructing a  plain-text result from the html-result we already have in Atom, but that is quite a lot of work if want to do it with standardized methods. 

If not, we could just clone the result-`node`, set all descendents to be visible and use [`node.innerText`](https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText). This would of course mean that we wouldn't have to transmit any extra data and also would get the exactly the same representation as in Atom. Note, however, that when lazy-loading of complete arrays lands (hopefully soonish :)) this wouldn't work as intended any more and we'd need another solution anyways. Like this one. Phew.

ink-side is at https://github.com/JunoLab/atom-ink/pull/18