### PR TITLE
Add handlers and renderers for docs and methods

### DIFF
--- a/src/display/objects.jl
+++ b/src/display/objects.jl
@@ -71,3 +71,7 @@ function handleundefs(X::Vector, inds)
   end
   Xout
 end
+
+@render i::Inline x::Base.Markdown.MD HTML(Base.Markdown.html(x))
+
+@render i::Inline x::MethodTable x

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -99,3 +99,13 @@ handle("eval-repl") do data
     end
   end
 end
+
+handle("docs") do data
+  result = @errs include_string("@doc $(data["code"])")
+  @d(:result => render(Editor(), result))
+end
+
+handle("methods") do data
+  result = @errs include_string("methods($(data["code"]))")
+  @d(:result => render(Editor(), result))
+end


### PR DESCRIPTION
This is the Julia side for supporting docs-at-a-keystroke in Atom.