### PR TITLE
Handle undef entries in vectors

### DIFF
--- a/src/display/objects.jl
+++ b/src/display/objects.jl
@@ -59,3 +59,19 @@ end
 end
 
 @render i::Inline x::Number Text(sprint(show, x))
+
+function handleundefs(X::Array)
+  Xout = Array{Union{ASCIIString, eltype(X)}}(size(X))
+  for i = 1:prod(size(X))
+    Xout[i] = isdefined(X, i) ? X[i] : "#undef"
+  end
+  Xout
+end
+
+function handleundefs(X::Array, inds)
+  Xout = Array{Union{ASCIIString, eltype(X)}}(size(X))
+  for i in lininds
+    Xout[i] = isdefined(X, i) ? X[i] : "#undef"
+  end
+  Xout
+end

--- a/src/display/objects.jl
+++ b/src/display/objects.jl
@@ -39,8 +39,8 @@ import Base.Docs: doc
 end
 
 @render Inline xs::Vector begin
-  length(xs) <= 25 ? children = xs :
-                     children = [xs[1:10]; span("..."); xs[end-9:end]]
+  length(xs) <= 25 ? children = handleundefs(xs) :
+                     children = [handleundefs(xs, 1:10); span("..."); handleundefs(xs, length(xs)-9:length(xs))]
     Tree(span(strong("Vector"),
               fade(" $(eltype(xs)), $(length(xs))")),
          children)
@@ -60,18 +60,14 @@ end
 
 @render i::Inline x::Number Text(sprint(show, x))
 
-function handleundefs(X::Array)
-  Xout = Array{Union{ASCIIString, eltype(X)}}(size(X))
-  for i = 1:prod(size(X))
-    Xout[i] = isdefined(X, i) ? X[i] : "#undef"
-  end
-  Xout
-end
+handleundefs(X::Vector) = handleundefs(X, 1:length(X))
 
-function handleundefs(X::Array, inds)
-  Xout = Array{Union{ASCIIString, eltype(X)}}(size(X))
-  for i in lininds
-    Xout[i] = isdefined(X, i) ? X[i] : "#undef"
+function handleundefs(X::Vector, inds)
+  Xout = Vector{Union{ASCIIString, eltype(X)}}(length(inds))
+  j = 1
+  for i in inds
+    Xout[j] = isdefined(X, i) ? X[i] : "#undef"
+    j += 1
   end
   Xout
 end


### PR DESCRIPTION
Fix for https://github.com/JunoLab/atom-julia-client/issues/44.

Since we aren't doing any special rendering with arrays, they work anyway. It would be really cool to have this work for arbitrary arrays, but I couldn't figure out how to do that without constructing an array of the same size as the array to be printed right now.
So when we implement nice Array printing, this should be overhauled.

Also: Right now undef elements are printed as `"#undef"`, but that's only a small cosmetic problem, methinks.