### PR TITLE
fix for not properly dealing with modules 

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -117,5 +117,5 @@ handle("methods") do data
   elseif wordtype == DataType
     result = @errs include_string("methodswith($word)")
   end
-  @d(:result => render(Editor(), result))
+  @d(:result => method_obj(result))
 end

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -101,11 +101,13 @@ handle("eval-repl") do data
 end
 
 handle("docs") do data
-  result = @errs include_string("@doc $(data["code"])")
+  mod = eval(parse(data["module"]))
+  result = @errs include_string(mod, "@doc $(data["code"])")
   @d(:result => render(Editor(), result))
 end
 
-handle("methods") do data
+handle("methods") do data#
+  mod = eval(parse(data["module"]))
   word = data["code"]
   wordtype = try
     include_string("typeof($word)")
@@ -113,9 +115,9 @@ handle("methods") do data
     Function
   end
   if wordtype == Function
-    result = @errs include_string("methods($word)")
+    result = @errs include_string(mod, "methods($word)")
   elseif wordtype == DataType
-    result = @errs include_string("methodswith($word)")
+    result = @errs include_string(mod, "methodswith($word)")
   end
   @d(:result => method_obj(result))
 end


### PR DESCRIPTION
The `eval(parse(mod))` thing is obviously a bit scary, but I dunno how else to construct a `Module` from a string... Any ideas anyone? @one-more-minute 

Also, this is on top of #20.