### PR TITLE
add MacroTools and Requires explicitly to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,5 @@ Hiccup
 Media
 Blink
 Reexport
+MacroTools
+Requires


### PR DESCRIPTION
if they're being directly used, they should be directly depended on,
rather than assuming they will be present as transitive deps of other packages