### PR TITLE
enable rendering of compose contexts

### DIFF
--- a/src/display/plots.jl
+++ b/src/display/plots.jl
@@ -28,3 +28,13 @@ end
   @render Inline v::Vega.VegaVisualization Text("Vega Visualisation")
   @render Clipboard v::Vega.VegaVisualization Text("Vega Visualisation")
 end
+
+@require Compose begin
+  @render PlotPane img::Compose.Context begin
+    HTML(stringmime(MIME"image/svg+xml"(), img))
+  end
+
+  @render e::Editor img::Compose.Context begin
+    Text("Compose.Context(...)")
+  end
+end


### PR DESCRIPTION
ref: https://github.com/JunoLab/Media.jl/pull/6

![compose](https://cloud.githubusercontent.com/assets/6735977/13494616/aef81224-e145-11e5-8b7b-800d841b1928.PNG)

This is very much preliminary support only.

I'm not sure about adding the `render(::Editor, plot::Compose.Context)` method, but Atom slows down way too much when displaying the entire result  inline. Also, this is similar to how Gadfly plots behave. 
Dunno what the best way forward is for these cases where we have side effects to evaluating something...
