### PR TITLE
inline markdown rendering

### DIFF
--- a/src/display/objects.jl
+++ b/src/display/objects.jl
@@ -80,3 +80,9 @@ end
 @render i::Inline xs::Tuple begin
   span(c("(", (@_ xs map(x->render(i, x), _) interpose(_, ", "))..., ")"))
 end
+
+@render i::Inline md::Base.Markdown.MD begin
+  mds = CodeTools.flatten(md)
+  length(mds) == 1 ? Text(chomp(sprint(show, MIME"text/markdown"(), md))) :
+                     Tree(Text("MD"), [HTML(sprint(show, MIME"text/html"(), md))])
+end


### PR DESCRIPTION
~~Short~~ design question: How do we want to handle different "rendering styles"?

Problem:
When rendering documentation in either a `Result > Tree > Children` or in a `InlineDoc` element, I don't want to create a `Tree` or `SubTree` for multiline Markdown but rather render the whole thing. But when rendering it inline, i.e. as a toplevel result, I want the implementation proposed here and create a `Tree`.

We should probably just create a new type and specialize our rendering methods on that to get that behaviour -- first I was thinking of something like `Underline`, but maybe something like `Verbose` fits better? 
If we do this, how would it integrate with the rest of the display system on the Julia side?