### PR TITLE
RFC: scrub backtrace before showing

### DIFF
--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -16,9 +16,12 @@ function splitlink(path)
 end
 
 # TODO: don't work on the text
-# TODO: clip traces so Atom/CodeTools doesn't show up
 
 function btlines(bt, top_function::Symbol = :eval_user_input, set = 1:typemax(Int))
+  include_ind = Base.REPL.findfirst(addr->Base.REPL.ip_matches_func(addr, :include_string), bt)
+  if include_ind != 0
+    bt = bt[1:include_ind-1]
+  end
   @_ begin
     sprint(Base.show_backtrace, bt)
     split(_, "\n")


### PR DESCRIPTION
This is just an idea for scrubbing the backtraces before showing it to the user. Right now, the unnecessary junk we want to get rid of is

```jl
 in include_string(::String, ::String) at ./loading.jl:380
 in include_string(::String, ::String, ::Int64) at /home/kristoffer/.julia/v0.5/CodeTools/src/eval.jl:28
 in include_string(::Module, ::String, ::String, ::Int64, ::Vararg{Int64,N}) at /home/kristoffer/.julia/v0.5/CodeTools/src/eval.jl:32
 in (::Atom.##89#92{String,Int64,String})() at /home/kristoffer/.julia/v0.5/Atom/src/eval.jl:39
 in withpath(::Atom.##89#92{String,Int64,String}, ::String) at /home/kristoffer/.julia/v0.5/Requires/src/require.jl:37
 in withpath(::Function, ::String) at /home/kristoffer/.julia/v0.5/Atom/src/eval.jl:45
 in macro expansion at /home/kristoffer/.julia/v0.5/Atom/src/eval.jl:56 [inlined]
 in (::Atom.##88#91{String,Int64,String})() at ./task.jl:54
```

So what I am doing now is just finding the first `include_string` and remove everything after that. This is probably not strictly correct since a user could maybe have a non junk `include_string` call in his/her code.

I am not sure exactly what is best here but I am rolling with this locally and love that the backtraces are not crazy big anymore...

Maybe there could be some heuristic for example finding the first `include_string` in `CodeTools` and then remove all stack frames from one above that to the end.