### PR TITLE
RFC: hide function argument types in backtrace

### DIFF
--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -19,7 +19,7 @@ function btlines(bt)
   isempty(bt) && return []
   trace = Base.stacktrace(bt)
   t_trace = map(trace) do frame
-    (sprint(Base.StackTraces.show_spec_linfo, frame),
+    (split(sprint(Base.StackTraces.show_spec_linfo, frame), '(')[1],
     string(frame.file),
     frame.line,
     frame.inlined ? " [inlined]" : "")


### PR DESCRIPTION
Always scrolling to the right to find the line info in the error box gets a bit tedious. For interactive use like in Atom I believe that showing all the types that go into the functions in the backtrace is overkill. It is simple to click the link and look at the actual function if one wants to.