### PR TITLE
Improve startup time

### DIFF
--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -25,4 +25,6 @@ end
 # include("blink/BlinkDisplay.jl")
 # @reexport using .BlinkDisplay
 
+include("precompile.jl")
+
 end # module

--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module Atom
 
-using Juno, Lazy, JSON, Blink, MacroTools, Reexport
+using Juno, Lazy, JSON, MacroTools, Reexport
 
 @init Juno.activate()
 
@@ -22,7 +22,7 @@ else
   include("debugger/mockingbird.jl")
 end
 
-include("blink/BlinkDisplay.jl")
-@reexport using .BlinkDisplay
+# include("blink/BlinkDisplay.jl")
+# @reexport using .BlinkDisplay
 
 end # module

--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -15,7 +15,7 @@ include("frontend.jl")
 include("utils.jl")
 
 # only require the debugger on 0.5.x for now and we aren't on x86 Windows
-@static if VERSION.minor == 5 && !(Sys.WORD_SIZE == 32 && is_windows())
+@static if false#VERSION.minor == 5 && !(Sys.WORD_SIZE == 32 && is_windows())
   include("debugger/debugger.jl")
   @reexport using .Debugger
 else

--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -13,14 +13,7 @@ include("completions.jl")
 include("misc.jl")
 include("frontend.jl")
 include("utils.jl")
-
-# only require the debugger on 0.5.x for now and we aren't on x86 Windows
-@static if false#VERSION.minor == 5 && !(Sys.WORD_SIZE == 32 && is_windows())
-  include("debugger/debugger.jl")
-  @reexport using .Debugger
-else
-  include("debugger/mockingbird.jl")
-end
+include("debugger/load.jl")
 
 # include("blink/BlinkDisplay.jl")
 # @reexport using .BlinkDisplay

--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module Atom
 
-using Juno, Lazy, JSON, MacroTools, Reexport
+using Juno, Lazy, JSON, Blink, MacroTools, Reexport
 
 @init Juno.activate()
 
@@ -15,8 +15,8 @@ include("frontend.jl")
 include("utils.jl")
 include("debugger/load.jl")
 
-# include("blink/BlinkDisplay.jl")
-# @reexport using .BlinkDisplay
+include("blink/BlinkDisplay.jl")
+@reexport using .BlinkDisplay
 
 include("precompile.jl")
 

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -77,7 +77,7 @@ a welcome message to Atom if `welcome == true`.
 function initialise(; welcome = false)
   Juno.setactive!(true)
   exit_on_sigint(false)
-  # eval(AtomShell, :(_shell = $(Shell())))
+  eval(AtomShell, :(_shell = $(Shell())))
   welcome && @msg welcome()
 end
 

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -99,6 +99,18 @@ function serve(port; kws...)
   end
   initialise(; kws...)
 end
+
+function connect(port; kws...)
+  global sock = Base.connect(ip"127.0.0.1", port)
+  @async while isopen(sock)
+    @ierrs let
+      msg = JSON.parse(sock)
+      @schedule @ierrs handlemsg(msg...)
+    end
+  end
+  initialise(; kws...)
+end
+
 """
     msg(typ, args...)
 

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -75,6 +75,7 @@ Sets up the environment for Atom.jl: Stop `SIGINT`s from killing Julia and send
 a welcome message to Atom if `welcome == true`.
 """
 function initialise(; welcome = false)
+  Juno.isprecompiling() && return
   Juno.setactive!(true)
   exit_on_sigint(false)
   eval(AtomShell, :(_shell = $(Shell())))

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -77,7 +77,7 @@ a welcome message to Atom if `welcome == true`.
 function initialise(; welcome = false)
   Juno.setactive!(true)
   exit_on_sigint(false)
-  eval(AtomShell, :(_shell = $(Shell())))
+  # eval(AtomShell, :(_shell = $(Shell())))
   welcome && @msg welcome()
 end
 

--- a/src/debugger/entry.jl
+++ b/src/debugger/entry.jl
@@ -15,11 +15,6 @@ function step(args...)
   RunDebugIDE(enter_call_expr(nothing, :($(args...)())))
 end
 
-macro step(ex)
-  @capture(ex, f_(args__)) || error("Syntax: @step f(...)")
-  :(step($(esc(f)), $(map(esc, args)...)))
-end
-
 # Breakpoints
 
 using Gallium

--- a/src/debugger/load.jl
+++ b/src/debugger/load.jl
@@ -1,0 +1,18 @@
+export Debugger
+
+function __debug__()
+  isdefined(Atom, :Debugger) && return
+  # only require the debugger on 0.5.x for now and we aren't on x86 Windows
+  if VERSION.minor == 5 && !(Sys.WORD_SIZE == 32 && is_windows())
+    @eval include(joinpath(dirname($@__FILE__), "debugger.jl"))
+  end
+end
+
+isdebugging() = isdefined(:Debugger) && Debugger.isdebugging()
+
+for f in :[step, breakpoint].args
+  @eval function $f(args...)
+    __debug__()
+    Debugger.$f(args...)
+  end
+end

--- a/src/debugger/load.jl
+++ b/src/debugger/load.jl
@@ -2,10 +2,7 @@ export Debugger
 
 function __debug__()
   isdefined(Atom, :Debugger) && return
-  # only require the debugger on 0.5.x for now and we aren't on x86 Windows
-  if VERSION.minor == 5 && !(Sys.WORD_SIZE == 32 && is_windows())
-    @eval include(joinpath(dirname($@__FILE__), "debugger.jl"))
-  end
+  @eval include(joinpath(dirname($@__FILE__), "debugger.jl"))
 end
 
 isdebugging() = isdefined(:Debugger) && Debugger.isdebugging()

--- a/src/debugger/mockingbird.jl
+++ b/src/debugger/mockingbird.jl
@@ -1,4 +1,0 @@
-# mock implementation for Julia versions where the Debugger doesn't work
-module Debugger
-isdebugging() = false
-end

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -98,7 +98,7 @@ handle("evalrepl") do data
   elseif mode == "help"
     code = "@doc $code"
   end
-  if Debugger.isdebugging()
+  if isdebugging()
     render(Console(), @errs Debugger.interpret(code))
   else
     try
@@ -187,7 +187,7 @@ handle("workspace") do mod
   # TODO: only filter out imported modules
   filter!(n -> !isa(getfield(mod, n), Module), ns)
   contexts = [d(:context => string(mod), :items => map(n -> wsitem(mod, n), ns))]
-  if Debugger.isdebugging()
+  if isdebugging()
     prepend!(contexts, Debugger.contexts())
   end
   return contexts

--- a/src/frontend.jl
+++ b/src/frontend.jl
@@ -28,24 +28,24 @@ end
 
 # Blink stuff
 
-type Shell <: AtomShell.Shell end
-
-AtomShell.active(::Shell) = true
-
-AtomShell.raw_window(::Shell, opts) =
-  @rpc createWindow(merge(AtomShell.window_defaults, opts))
-
-AtomShell.dot(::Shell, win::Integer, code; callback = true) =
-  (callback ? rpc : msg)(:withWin, win, Blink.jsstring(code))
-
-AtomShell.active(::Shell, win::Integer) = @rpc winActive(win)
+# type Shell <: AtomShell.Shell end
+#
+# AtomShell.active(::Shell) = true
+#
+# AtomShell.raw_window(::Shell, opts) =
+#   @rpc createWindow(merge(AtomShell.window_defaults, opts))
+#
+# AtomShell.dot(::Shell, win::Integer, code; callback = true) =
+#   (callback ? rpc : msg)(:withWin, win, Blink.jsstring(code))
+#
+# AtomShell.active(::Shell, win::Integer) = @rpc winActive(win)
 
 plotsize() = @rpc plotsize()
 
 ploturl(url::String) = @msg ploturl(url)
 
-function blinkplot()
-  p = Page()
-  ploturl(Blink.localurl(p))
-  return wait(p)
-end
+# function blinkplot()
+#   p = Page()
+#   ploturl(Blink.localurl(p))
+#   return wait(p)
+# end

--- a/src/frontend.jl
+++ b/src/frontend.jl
@@ -28,24 +28,24 @@ end
 
 # Blink stuff
 
-# type Shell <: AtomShell.Shell end
-#
-# AtomShell.active(::Shell) = true
-#
-# AtomShell.raw_window(::Shell, opts) =
-#   @rpc createWindow(merge(AtomShell.window_defaults, opts))
-#
-# AtomShell.dot(::Shell, win::Integer, code; callback = true) =
-#   (callback ? rpc : msg)(:withWin, win, Blink.jsstring(code))
-#
-# AtomShell.active(::Shell, win::Integer) = @rpc winActive(win)
+type Shell <: AtomShell.Shell end
+
+AtomShell.active(::Shell) = true
+
+AtomShell.raw_window(::Shell, opts) =
+  @rpc createWindow(merge(AtomShell.window_defaults, opts))
+
+AtomShell.dot(::Shell, win::Integer, code; callback = true) =
+  (callback ? rpc : msg)(:withWin, win, Blink.jsstring(code))
+
+AtomShell.active(::Shell, win::Integer) = @rpc winActive(win)
 
 plotsize() = @rpc plotsize()
 
 ploturl(url::String) = @msg ploturl(url)
 
-# function blinkplot()
-#   p = Page()
-#   ploturl(Blink.localurl(p))
-#   return wait(p)
-# end
+function blinkplot()
+  p = Page()
+  ploturl(Blink.localurl(p))
+  return wait(p)
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,22 @@
+const precomp = [
+  ["cd", homedir()],
+  [Dict(:callback=>1, :type=>:ping)],
+  [Dict(:callback=>1, :type=>:evalrepl),Dict(:code=>2+2,:mod=>"Main",:mode=>"julia")],
+  ["clearLazy", []],
+  [Dict(:callback=>3,:type=>"workspace"),"Main"],
+]
+
+function precompile()
+  server = listen(ip"127.0.0.1", 3000)
+  task = @schedule @sync connect(3000)
+  mock = accept(server)
+
+  for msg in precomp
+    println(sock, json(msg))
+  end
+
+  close(mock)
+  wait(task)
+end
+
+Juno.isprecompiling() && precompile()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,9 +5,11 @@ edit(pkg) =
 
 isuntitled(p) = ismatch(r"^(\.\\|\./)?untitled-[\d\w]+(:\d+)?$", p)
 
+jlhome() = ccall(:jl_get_julia_home, Any, ())
+
 function basepath(file)
-  srcdir = joinpath(JULIA_HOME,"..","..","base")
-  releasedir = joinpath(JULIA_HOME,"..","share","julia","base")
+  srcdir = joinpath(jlhome(),"..","..","base")
+  releasedir = joinpath(jlhome(),"..","share","julia","base")
   normpath(joinpath(isdir(srcdir) ? srcdir : releasedir, file))
 end
 


### PR DESCRIPTION
I've made several changes which improve Julia's boot time in Juno:

* Improve load time of various dependencies
* Lazy load gallium (obviously this cost must still be paid, which slows down first use)
* Do more precompilation
* Reduce the required negotiation by using julia-as-client locally

The median boot time is now about 3s on my laptop. For more we most likely need to expand the amount of pre-compilation done in other packages.