### PR TITLE
render evalall result into console

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -78,7 +78,10 @@ handle("evalall") do data
   @dynamic let Media.input = Editor()
     withpath(path) do
       try
-        include_string(mod, code, path)
+        result = include_string(mod, code, path)
+        display = Media.getdisplay(typeof(result), Media.pool(Editor()), default = Console())
+        render(Console(), result)
+        display ≠ Console() && render(display, result)
       catch e
         ee = EvalError(e, catch_backtrace())
         render(Console(), ee)


### PR DESCRIPTION
This will show the result of the last block in the console, consitent with `include()`ing files in the REPL. 