### PR TITLE
use 0.6.0-pre as julia lower bound

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Juno 0.2.6
 Lazy 0.11.3
 LNR


### PR DESCRIPTION
for where syntax to work, shouldn't claim to support early dev versions