### PR TITLE
remove dependency on gallium and astinterpreter

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -9,5 +9,3 @@ Media
 Blink
 Reexport
 MacroTools
-ASTInterpreter
-Gallium


### PR DESCRIPTION
This actually works without any changes in code, since Gallium and ASTInterpreter always were loaded dynamically; the code that does this checks the Julia version, so we can't get a "missing package" warning from this.

Fixes https://github.com/JunoLab/Atom.jl/issues/91.