### PR TITLE
location-dependent stackframe shading

### DIFF
--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -43,11 +43,22 @@ highlights(trace::StackTrace) =
 
 highlights(e::EvalError) = highlights(e.trace)
 
+function locationshading(file)
+  f, p = expandpath(file)
+
+  # error in base
+  ismatch(r"^base/.*", f) && return ".dark"
+  # error in package
+  contains(p, Pkg.dir()) && return ".medium"
+  # error in "user code"
+  return ".bright"
+end
+
 function renderbt(trace::StackTrace)
   span(".error-trace",
-       [div(".trace-entry",
-            c(fade("in "), string(frame.func), fade(" at "),
-              render(Inline(), Copyable(baselink(string(frame.file), frame.line)))))
+       [div(".trace-entry $(locationshading(string(frame.file)))",
+            [fade("in "), string(frame.func), fade(" at "),
+             render(Inline(), Copyable(baselink(string(frame.file), frame.line)))])
         for frame in reverse(trace)])
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,5 +35,5 @@ expandpath(path) =
 function baselink(path, line)
   name, path = expandpath(path)
   name == "<unkown file>" ? span(".fade", "<unknown file>") :
-  link(path, line, Text(appendline(name, line)))
+                            link(path, line, Text(appendline(name, line)))
 end


### PR DESCRIPTION
![screenshot_20170702_131605](https://user-images.githubusercontent.com/6735977/27769410-e55f578e-5f28-11e7-94e0-d78ade91257e.png)

Stackframes that point to base functions are dimmed, those from packages are slightly brighter and those from user code (everything not in `Pkg.dir()` or `base`) are brightest.

Inspired by https://github.com/JuliaLang/julia/issues/22653.
Needs https://github.com/JunoLab/atom-julia-client/pull/368.