### PR TITLE
Call invokelatest on `render` and `media`

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -151,7 +151,7 @@ end
 
 ismacro(f::Function) = startswith(string(methods(f).mt.name), "@")
 
-wstype(x) = nothing
+wstype(x) = ""
 wstype(::Module) = "module"
 wstype(f::Function) = ismacro(f) ? "mixin" : "function"
 wstype(::Type) = "type"
@@ -161,8 +161,8 @@ wstype(::AbstractString) = "property"
 wstype(::Number) = "constant"
 wstype(::Exception) = "tag"
 
-wsicon(x) = nothing
-wsicon(f::Function) = ismacro(f) ? "icon-mention" : nothing
+wsicon(x) = ""
+wsicon(f::Function) = ismacro(f) ? "icon-mention" : ""
 wsicon(::AbstractArray) = "icon-file-binary"
 wsicon(::AbstractVector) = "icon-list-ordered"
 wsicon(::AbstractString) = "icon-quote"
@@ -177,7 +177,7 @@ wsnamed(name, m::Module) = name == module_name(m)
 wsnamed(name, T::DataType) = name == Symbol(T.name)
 
 function wsitem(name::Symbol, val)
-  d(:name  => wsnamed(name, val) ? nothing : name,
+  d(:name  => name,
     :value => render′(Inline(), val),
     :type  => wstype(val),
     :icon  => wsicon(val))

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -7,12 +7,6 @@ LNR.cursor(data::Associative) = cursor(data["row"], data["column"])
 
 exit_on_sigint(on) = ccall(:jl_exit_on_sigint, Void, (Cint,), on)
 
-# define this until Base's invokelatest can handle kwargs
-function invokelatestkw(f, args...; kwargs...)
-  inner = () -> f(args...; kwargs...)
-  Core._apply_latest(inner)
-end
-
 function modulenames(data, pos)
   main = haskey(data, "module") ? data["module"] :
          haskey(data, "path") ? CodeTools.filemodule(data["path"]) :
@@ -56,11 +50,12 @@ handle("eval") do data
       @errs include_string(mod, text, path, line)
     end
     unlock(evallock)
-
-    display = invokelatestkw(Media.getdisplay, typeof(result), Media.pool(Editor()), default = Editor())
-    !isa(result,EvalError) && ends_with_semicolon(text) && (result = nothing)
-    display ≠ Editor() && result ≠ nothing && invokelatestkw(render, display, result)
-    invokelatestkw(render′, Editor(), result)
+    Base.invokelatest() do
+      display = Media.getdisplay(typeof(result), Media.pool(Editor()), default = Editor())
+      !isa(result,EvalError) && ends_with_semicolon(text) && (result = nothing)
+      display ≠ Editor() && result ≠ nothing && render(display, result)
+      render′(Editor(), result)
+    end
   end
 end
 
@@ -107,7 +102,7 @@ handle("evalrepl") do data
         withpath(nothing) do
           result = @errs eval(mod, :(ans = include_string($code, "console")))
           !isa(result,EvalError) && ends_with_semicolon(code) && (result = nothing)
-          invokelatestkw(render′, result)
+          Base.invokelatest(render′, result)
         end
         unlock(evallock)
       catch e

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -57,7 +57,7 @@ handle("eval") do data
     end
     unlock(evallock)
 
-    display = invokelatestmethod(Media.getdisplay, typeof(result), Media.pool(Editor()), default = Editor())
+    display = invokelatestkw(Media.getdisplay, typeof(result), Media.pool(Editor()), default = Editor())
     !isa(result,EvalError) && ends_with_semicolon(text) && (result = nothing)
     display ≠ Editor() && result ≠ nothing && invokelatestkw(render, display, result)
     invokelatestkw(render′, Editor(), result)


### PR DESCRIPTION
When a package defines a display for a certain type via `Media.media`, that internally calls something like `@eval media(...)`; right after that it's impossible to call any `render` methods, because of world age issues. 
Example would be something like `using Plots; plot([1,2,3])`, which only properly works on the subsequent call to `plot()`.

Together with https://github.com/JuliaPlots/Plots.jl/pull/916 (and https://github.com/JunoLab/atom-ink/pull/139, I guess) this makes the Plots.jl experience much nicer.