### PR TITLE
reverse backtrace-reversion

### DIFF
--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -57,9 +57,10 @@ end
 function renderbt(trace::StackTrace)
   span(".error-trace",
        [div(".trace-entry $(locationshading(string(frame.file)))",
-            [fade("in "), string(frame.func), fade(" at "),
-             render(Inline(), Copyable(baselink(string(frame.file), frame.line)))])
-        for frame in reverse(trace)])
+            [fade("in "), isnull(frame.linfo) ? string(frame.func) : sprint(Base.show_tuple_as_call, get(frame.linfo).def.name, get(frame.linfo).specTypes),
+             fade(" at "),
+             render(Inline(), Copyable(baselink(string(frame.file), frame.line))), frame.inlined ? " <inlined>" : ""])
+        for frame in trace])
 end
 
 rendererr(err) = strong(".error-description", err)

--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -60,7 +60,8 @@ function renderbt(trace::StackTrace)
             [fade("in "),
              isnull(frame.linfo) ?
                string(frame.func) :
-               sprint(Base.show_tuple_as_call, get(frame.linfo).def.name, get(frame.linfo).specTypes),
+               replace(sprint(Base.show_tuple_as_call, get(frame.linfo).def.name, get(frame.linfo).specTypes),
+                       r"\(.*\)$", ""),
              fade(" at "),
              render(Inline(), Copyable(baselink(string(frame.file), frame.line))),
              fade(frame.inlined ? " <inlined>" : "")])

--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -57,7 +57,8 @@ end
 function renderbt(trace::StackTrace)
   span(".error-trace",
        [div(".trace-entry $(locationshading(string(frame.file)))",
-            [fade("in "), isnull(frame.linfo) ? string(frame.func) : sprint(Base.show_tuple_as_call, get(frame.linfo).def.name, get(frame.linfo).specTypes),
+            [fade("in "),
+             isnull(frame.linfo) ? string(frame.func) : sprint(Base.show_tuple_as_call, get(frame.linfo).def.name, get(frame.linfo).specTypes),
              fade(" at "),
              render(Inline(), Copyable(baselink(string(frame.file), frame.line))), frame.inlined ? " <inlined>" : ""])
         for frame in trace])

--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -58,9 +58,12 @@ function renderbt(trace::StackTrace)
   span(".error-trace",
        [div(".trace-entry $(locationshading(string(frame.file)))",
             [fade("in "),
-             isnull(frame.linfo) ? string(frame.func) : sprint(Base.show_tuple_as_call, get(frame.linfo).def.name, get(frame.linfo).specTypes),
+             isnull(frame.linfo) ?
+               string(frame.func) :
+               sprint(Base.show_tuple_as_call, get(frame.linfo).def.name, get(frame.linfo).specTypes),
              fade(" at "),
-             render(Inline(), Copyable(baselink(string(frame.file), frame.line))), frame.inlined ? " <inlined>" : ""])
+             render(Inline(), Copyable(baselink(string(frame.file), frame.line))),
+             fade(frame.inlined ? " <inlined>" : "")])
         for frame in trace])
 end
 

--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -64,7 +64,7 @@ function renderbt(trace::StackTrace)
              fade(" at "),
              render(Inline(), Copyable(baselink(string(frame.file), frame.line))),
              fade(frame.inlined ? " <inlined>" : "")])
-        for frame in trace])
+        for frame in reverse(trace)])
 end
 
 rendererr(err) = strong(".error-description", err)


### PR DESCRIPTION
also better rendering of constructors in backtraces.

Before:
![image](https://user-images.githubusercontent.com/6735977/28966449-8bce7c88-7916-11e7-93ae-393154b472c2.png)

After:
![image](https://user-images.githubusercontent.com/6735977/28966430-7599dcf0-7916-11e7-8c80-d623355a5dc5.png)

~~Fixes https://github.com/JunoLab/atom-julia-client/issues/374~~.
