### PR TITLE
Use base display system for plots in repl

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -193,26 +193,10 @@ function changeREPLmodule(mod)
   end
 end
 
-struct PlotPaneDisplay <: Base.Multimedia.Display end
-
-function Base.display(d::PlotPaneDisplay, m::Union{MIME"image/png",
-                                                   MIME"image/svg+xml",
-                                                   MIME"juno/plotpane"}, plt)
-  Juno.render(Juno.PlotPane(), plt)
-end
-
-function Base.display(d::PlotPaneDisplay, x)
-  if mimewritable("image/svg+xml", x)
-    display(d, "image/svg+xml", x)
-  elseif mimewritable("image/png", x)
-    display(d, "image/png", x)
-  elseif mimewritable("juno/plotpane", x)
-    display(d, "juno/plotpane", x)
-  else
-    throw(MethodError(display, (d, x)))
-  end
-end
-
+# make sure DisplayHook() is higher than REPLDisplay() in the display stack
 @init begin
-  atreplinit((i) -> pushdisplay(PlotPaneDisplay()))
+  atreplinit((i) -> begin
+    Base.Multimedia.popdisplay(Media.DisplayHook())
+    Base.Multimedia.pushdisplay(Media.DisplayHook())
+  end
 end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -198,7 +198,7 @@ struct PlotPaneDisplay <: Base.Multimedia.Display end
 function Base.display(d::PlotPaneDisplay, m::Union{MIME"image/png",
                                                    MIME"image/svg+xml",
                                                    MIME"juno/plotpane"}, plt)
-  Juno.render(Juno.PlotPane(), HTML(stringmime(MIME("text/html"), plt)))
+  Juno.render(Juno.PlotPane(), plt)
 end
 
 function Base.display(d::PlotPaneDisplay, x)

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -213,9 +213,6 @@ function Base.display(d::PlotPaneDisplay, x)
   end
 end
 
-displayble(d::PlotPaneDisplay, ::MIME"image/png") = true
-displayble(d::PlotPaneDisplay, ::MIME"image/svg+xml") = true
-
 @init begin
   atreplinit((i) -> pushdisplay(PlotPaneDisplay()))
 end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -206,7 +206,7 @@ function Base.display(d::PlotPaneDisplay, x)
     display(d, "image/svg+xml", x)
   elseif mimewritable("image/png", x)
     display(d, "image/png", x)
-  elseif mimewriteable("juno/plotpane", x)
+  elseif mimewritable("juno/plotpane", x)
     display(d, "juno/plotpane", x)
   else
     throw(MethodError(display, (d, x)))

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -192,3 +192,30 @@ function changeREPLmodule(mod)
     return ret
   end
 end
+
+struct PlotPaneDisplay <: Base.Multimedia.Display end
+
+function Base.display(d::PlotPaneDisplay, m::Union{MIME"image/png",
+                                                   MIME"image/svg+xml",
+                                                   MIME"juno/plotpane"}, plt)
+  Juno.render(Juno.PlotPane(), HTML(stringmime(MIME("text/html"), plt)))
+end
+
+function Base.display(d::PlotPaneDisplay, x)
+  if mimewritable("image/svg+xml", x)
+    display(d, "image/svg+xml", x)
+  elseif mimewritable("image/png", x)
+    display(d, "image/png", x)
+  elseif mimewriteable("juno/plotpane", x)
+    display(d, "juno/plotpane", x)
+  else
+    throw(MethodError(display, (d, x)))
+  end
+end
+
+displayble(d::PlotPaneDisplay, ::MIME"image/png") = true
+displayble(d::PlotPaneDisplay, ::MIME"image/svg+xml") = true
+
+@init begin
+  atreplinit((i) -> pushdisplay(PlotPaneDisplay()))
+end


### PR DESCRIPTION
This allows using Plots.jl (and presumably other plotting packages) in the new REPL-based console together with the plotpane, but unfortunately doesn't yet take plotpane size into account. I'm not sure how to best handle that, but thought I'd throw this out there and hope someone has a good idea.

cc @MikeInnes and @ChrisRackauckas