### PR TITLE
reverse stacktraces (again)

### DIFF
--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -64,7 +64,7 @@ function renderbt(trace::StackTrace)
              fade(" at "),
              render(Inline(), Copyable(baselink(string(frame.file), frame.line))),
              fade(frame.inlined ? " <inlined>" : "")])
-        for frame in reverse(trace)])
+        for frame in trace])
 end
 
 rendererr(err) = strong(".error-description", err)


### PR DESCRIPTION
Fixes https://github.com/JunoLab/atom-julia-client/issues/374.

I'm strongly in favour of this just to be consistent -- is this okay with you, @MikeInnes?