### PR TITLE
WIP: switch to using REPLCompletions.complete

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -61,12 +61,14 @@ strlimit(str::AbstractString, limit = 30) = lastindex(str) > limit ?  str[1:prev
 using Base.Docs
 function completionsummary(mod, c)
   ct = REPLCompletions.completion_text(c)
+  Base.isdeprecated(mod, Symbol(ct)) && return
   b = Docs.Binding(mod, Symbol(ct))
   description(b)
 end
 
 function completionsummary(mod, c::REPLCompletions.MethodCompletion)
   b = Docs.Binding(mod, Symbol(c.func))
+  Base.isdeprecated(mod, Symbol(c.func)) && return
   description(b, Base.tuple_type_tail(c.method.sig))
 end
 

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -62,10 +62,28 @@ using Base.Docs
 function completionsummary(mod, c)
   ct = REPLCompletions.completion_text(c)
   b = Docs.Binding(mod, Symbol(ct))
-  CodeTools.description(b)
+  description(b)
 end
 
 function completionsummary(mod, c::REPLCompletions.MethodCompletion)
+  b = Docs.Binding(mod, Symbol(c.func))
+  description(b, Base.tuple_type_tail(c.method.sig))
+end
+
+using Markdown
+function description(binding, sig = Union{})
+  docs = Docs.doc(binding, sig)
+  docs isa Markdown.MD || return
+  md = CodeTools.flatten(docs).content
+  for part in md
+    if part isa Markdown.Paragraph
+      desc = Markdown.plain(part)
+      occursin("No documentation found.", desc) && return
+      return strlimit(desc, 100)
+    end
+  end
+end
+
 function completionmodule(mod, c)
   c isa REPLCompletions.ModuleCompletion ? string(c.parent) : string(mod)
 end

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -111,7 +111,7 @@ function completiontype(line, x, mod)
     end
 
     if f
-      return completiontype(t, x.parent)
+      return completiontype(t, x.parent, ct)
     end
   end
   x isa REPLCompletions.KeywordCompletion ? "keyword" :
@@ -123,14 +123,14 @@ function completiontype(line, x, mod)
     ""
 end
 
-function completiontype(x, mod)
+function completiontype(x, mod::Module, ct::AbstractString)
   x <: Module   ? "module"   :
   x <: DataType ? "type"     :
   x isa Type{<:Type} ? "type" :
   typeof(x) == UnionAll ? "type" :
   x <: Function ? "function" :
   x <: Tuple ? "tuple" :
-  isconst(mod, Symbol(x)) ? "constant" : ""
+  isconst(mod, Symbol(ct)) ? "constant" : ""
 end
 
 handle("cacheCompletions") do mod

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -22,23 +22,61 @@ function basecompletionadapter(line, mod)
   pre = line[cs[2]]
   d = []
   for c in cs[1]
-    push!(d, Dict{Any, Any}(:type => completiontype(line, cs[2], c, mod),
-                  :description => nothing,
-                  :rightLabel => completionmodule(mod, c),
-                  :text => string(REPLCompletions.completion_text(c)),
-                  :displayText => nothing))
+    # TODO: get local completions from CSTParser or similar
+    # TODO: would be cool to provide `descriptionMoreURL` here to open the docpane
+    push!(d, completion(mod, line, c))
   end
   d, pre
 end
 
+function completion(mod, line, c)
+  return Dict(:type => completiontype(line, c, mod),
+              :description => nothing,
+              :rightLabel => completionmodule(mod, c),
+              :leftLabel => returntype(mod, line, c),
+              :text => completiontext(c),
+              :description => completionsummary(mod, c))
+end
+
+completiontext(x) = REPLCompletions.completion_text(x)
+function completiontext(x::REPLCompletions.MethodCompletion)
+  ct = REPLCompletions.completion_text(x)
+  ct = match(r"^(.*) in .*$", ct)
+  ct isa Nothing ? ct : ct[1]
+end
+
+returntype(mod, line, c) = ""
+function returntype(mod, line, c::REPLCompletions.MethodCompletion)
+  m = c.method
+  atypes = m.sig
+  sparams = m.sparam_syms
+  wa = Core.Compiler.Params(typemax(UInt))  # world age
+  inf = Core.Compiler.typeinf_type(m, atypes, sparams, wa)
+
+  strlimit(string(inf), 20)
+end
+
+strlimit(str::AbstractString, limit = 30) = lastindex(str) > limit ?  str[1:prevind(str, limit)]*"…" : str
+
+using Base.Docs
+function completionsummary(mod, c)
+  ct = REPLCompletions.completion_text(c)
+  b = Docs.Binding(mod, Symbol(ct))
+  CodeTools.description(b)
+end
+
+function completionsummary(mod, c::REPLCompletions.MethodCompletion)
 function completionmodule(mod, c)
   c isa REPLCompletions.ModuleCompletion ? string(c.parent) : string(mod)
 end
 
-function completiontype(line, inds, x, mod)
+function completiontype(line, x, mod)
+  ct = REPLCompletions.completion_text(x)
+  startswith(ct, '@') && return "macro"
+
   if x isa REPLCompletions.ModuleCompletion
     t, f = try
-      str = string(line[1:(first(inds)-1)], REPLCompletions.completion_text(x))
+      str = string(line[1:(first(inds)-1)], ct)
       REPLCompletions.get_type(Meta.parse(str, raise=false, depwarn=false), mod)
     catch e
       nothing, false
@@ -52,7 +90,7 @@ function completiontype(line, inds, x, mod)
     x isa REPLCompletions.PropertyCompletion ? "property" :
     x isa REPLCompletions.FieldCompletion ? "field" :
     x isa REPLCompletions.MethodCompletion ? "λ" :
-    " "
+    "v"
 end
 
 function completiontype(x)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -5,16 +5,61 @@ matchesprefix(c, ::Nothing) = true
 handle("completions") do data
   @destruct [path || nothing, mod || "Main", line, force] = data
   withpath(path) do
-    pre = CodeTools.prefix(line)
-    pre = isempty(pre) ? nothing : pre[end]
     m = getthing(mod)
     m = isa(m, Module) ? m : Main
-    cs = CodeTools.completions(line, m, default = false)
-    cs == nothing && pre == nothing && !force && (cs = [])
+
+    cs, pre = basecompletionadapter(line, m)
+
     d(:completions => cs,
-      :prefix      => pre,
-      :mod         => mod)
+      :prefix      => string(pre),
+      :mod         => string(mod))
   end
+end
+
+using REPL.REPLCompletions
+function basecompletionadapter(line, mod)
+  cs = REPL.REPLCompletions.completions(line, lastindex(line), mod)
+  pre = line[cs[2]]
+  d = []
+  for c in cs[1]
+    push!(d, Dict{Any, Any}(:type => completiontype(line, cs[2], c, mod),
+                  :description => nothing,
+                  :rightLabel => completionmodule(mod, c),
+                  :text => string(REPLCompletions.completion_text(c)),
+                  :displayText => nothing))
+  end
+  d, pre
+end
+
+function completionmodule(mod, c)
+  c isa REPLCompletions.ModuleCompletion ? string(c.parent) : string(mod)
+end
+
+function completiontype(line, inds, x, mod)
+  if x isa REPLCompletions.ModuleCompletion
+    t, f = try
+      str = string(line[1:(first(inds)-1)], REPLCompletions.completion_text(x))
+      REPLCompletions.get_type(Meta.parse(str, raise=false, depwarn=false), mod)
+    catch e
+      nothing, false
+    end
+
+    f && return completiontype(t)
+  end
+  x isa REPLCompletions.KeywordCompletion ? "keyword" :
+    x isa REPLCompletions.PathCompletion ? "path" :
+    x isa REPLCompletions.PackageCompletion ? "module" :
+    x isa REPLCompletions.PropertyCompletion ? "property" :
+    x isa REPLCompletions.FieldCompletion ? "field" :
+    x isa REPLCompletions.MethodCompletion ? "λ" :
+    " "
+end
+
+function completiontype(x)
+  x <: Module   ? "module" :
+  x <: DataType ? "type"   :
+  x <: Function ? "λ"      :
+                  "constant"
 end
 
 handle("cacheCompletions") do mod

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -61,14 +61,14 @@ strlimit(str::AbstractString, limit = 30) = lastindex(str) > limit ?  str[1:prev
 using Base.Docs
 function completionsummary(mod, c)
   ct = REPLCompletions.completion_text(c)
-  Base.isdeprecated(mod, Symbol(ct)) && return
+  (!Base.isbindingresolved( mod, Symbol(ct)) || Base.isdeprecated(mod, Symbol(ct))) && return ""
   b = Docs.Binding(mod, Symbol(ct))
   description(b)
 end
 
 function completionsummary(mod, c::REPLCompletions.MethodCompletion)
   b = Docs.Binding(mod, Symbol(c.func))
-  Base.isdeprecated(mod, Symbol(c.func)) && return
+  (!Base.isbindingresolved( mod, Symbol(c.func)) || Base.isdeprecated(mod, Symbol(c.func))) && return ""
   description(b, Base.tuple_type_tail(c.method.sig))
 end
 
@@ -80,7 +80,7 @@ function description(binding, sig = Union{})
   for part in md
     if part isa Markdown.Paragraph
       desc = Markdown.plain(part)
-      occursin("No documentation found.", desc) && return
+      occursin("No documentation found.", desc) && return ""
       return strlimit(desc, 100)
     end
   end
@@ -121,7 +121,7 @@ function completiontype(x)
 end
 
 handle("cacheCompletions") do mod
-  m = getthing(mod)
-  m = isa(m, Module) ? m : Main
-  CodeTools.completions(m)
+  # m = getthing(mod)
+  # m = isa(m, Module) ? m : Main
+  # CodeTools.completions(m)
 end


### PR DESCRIPTION
Needs https://github.com/JunoLab/atom-julia-client/pull/492.

What we gain: 
- Completions for dict keys
- Completions for pathcompletions in strings
- Completions for struct field access
- Completion hints for methods (with inferred return type and method specific docstrings):
![screenshot_20180731_124711](https://user-images.githubusercontent.com/6735977/43457242-8124f4de-94c6-11e8-9141-0ef799cdbb4b.png)

What we lose:
- Fuzzy completions
- Performance on first call
