### PR TITLE
render all AbstractDict as a Tree

### DIFF
--- a/src/display/base.jl
+++ b/src/display/base.jl
@@ -120,7 +120,7 @@ end
   Text(sprint(io -> show(IOContext(io, :limit=>true), MIME"text/plain"(), xs)))
 end
 
-@render i::Inline d::Dict begin
+@render i::Inline d::AbstractDict begin
   j = 0
   st = Array{Atom.SubTree}(undef, 0)
   for (key, val) in d
@@ -128,7 +128,7 @@ end
     j += 1
     j > 25 && (push!(st, SubTree(span("... → "), span("..."))); break)
   end
-  Tree(span(c(strong("Dict"),
+  Tree(span(c(strong(String(nameof(typeof(d)))),
             Atom.fade(" $(eltype(d).parameters[1]) → $(eltype(d).parameters[2]) with $(length(d)) entries"))), st)
 end
 


### PR DESCRIPTION
I wanted to use nested `OrderedDict`, but was missing the nice drop down display of the `Dict`. I think this same method should be fine for any `AbstractDict` with this minor change.

Before:
![image](https://user-images.githubusercontent.com/4471859/47498677-40c55600-d85e-11e8-9cd9-6913e2521dcc.png)
After:
![image](https://user-images.githubusercontent.com/4471859/47498682-458a0a00-d85e-11e8-8bf7-a7d51b595484.png)
