### PR TITLE
Compatibility with Debugger.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -10,10 +10,12 @@ Media
 Reexport
 MacroTools
 DocSeeker
-ASTInterpreter2
-DebuggerFramework
-WebIO 0.6.0
 Requires
+WebIO 0.6.0
 HTTP
 WebSockets
 Traceur
+
+JuliaInterpreter
+Debugger
+CodeTracking

--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -49,7 +49,7 @@ include("misc.jl")
 include("frontend.jl")
 include("utils.jl")
 
-include("debugger/load.jl")
+include("debugger/debugger.jl")
 
 include("profiler/profiler.jl")
 include("profiler/traceur.jl")

--- a/src/debugger/breakpoints.jl
+++ b/src/debugger/breakpoints.jl
@@ -5,6 +5,7 @@ import Atom: basepath, handle
 
 handle("clearbps") do
   JuliaInterpreter.remove()
+  allbreakpoints()
 end
 
 # Juno.@render Juno.Inline bp::Gallium.Breakpoint begin
@@ -61,6 +62,24 @@ end
 handle("toggleBP") do file, line
   removebreakpoint(file, line) || addbreakpoint(file, line)
   allbreakpoints()
+end
+
+handle("getBreakpoints") do
+  allbreakpoints()
+end
+
+handle("toggleException") do
+  if JuliaInterpreter.break_on_error[]
+    JuliaInterpreter.break_off(:error)
+  else
+    JuliaInterpreter.break_on(:error)
+  end
+  return JuliaInterpreter.break_on_error[]
+end
+
+handle("toggleUncaught") do
+  @warn "not supported yet"
+  return false
 end
 
 function addbreakpoint(file, line)

--- a/src/debugger/breakpoints.jl
+++ b/src/debugger/breakpoints.jl
@@ -76,7 +76,11 @@ end
 
 handle("addArgs") do arg
   with_error_message() do
-    add_breakpoint_args(arg)
+    bp = add_breakpoint_args(arg)
+    isempty(bp) && error("""
+      Invalid spec. Please specify as `foo` or `foo(Bar, Baz)`, e.g. `sin` or `sin(Int)`. Make sure
+      the function and all types can be reached from `Main`.
+      """)
     allbreakpoints()
   end
 end

--- a/src/debugger/breakpoints.jl
+++ b/src/debugger/breakpoints.jl
@@ -27,11 +27,44 @@ handle("getbps") do
   ret
 end
 
-normbase(file) = contains(file, basepath("")) ? basename(file) : file
+function allbreakpoints()
+  bps = JuliaInterpreter.breakpoints()
+  filter!(x -> x ≠ nothing, simple_breakpoint.(bps))
+end
 
-handle("addsourcebp") do file, line
+function simple_breakpoint(bp::JuliaInterpreter.BreakpointRef)
+  file, line = location(bp)
+  isactive = bp[].isactive
+  condition = bp[].condition
+  condition = if condition == JuliaInterpreter.truecondition
+    "true"
+  elseif condition == JuliaInterpreter.falsecondition
+    "false"
+  else
+    string(condition)
+  end
+
+  if file ≠ nothing
+    shortpath, _ = Atom.expandpath(file)
+    return Dict(
+      :file => file,
+      :shortpath => shortpath,
+      :line => line - 1,
+      :isactive => isactive,
+      :condition => condition
+    )
+  else
+    return nothing
+  end
+end
+
+handle("toggleBP") do file, line
+  removebreakpoint(file, line) || addbreakpoint(file, line)
+  allbreakpoints()
+end
+
+function addbreakpoint(file, line)
   JuliaInterpreter.breakpoint(file, line)
-  return true
 end
 
 function location(bp::JuliaInterpreter.BreakpointRef)
@@ -39,19 +72,21 @@ function location(bp::JuliaInterpreter.BreakpointRef)
       lineno = JuliaInterpreter.linenumber(bp.framecode, bp.stmtidx)
       whereis(bp.framecode.scope)[1], lineno
   else
-      @warn "not a source BP"
+      nothing, 0
   end
 end
 
-handle("removesourcebp") do file, line
+function removebreakpoint(file, line)
   bps = JuliaInterpreter.breakpoints()
+  removed = false
   for bp in bps
     bp_file, bp_line = location(bp)
     if normpath(bp_file) == normpath(file) && bp_line == line
       JuliaInterpreter.remove(bp)
+      removed = true
     end
   end
-  return true
+  removed
 end
 
 function breakpoint(args...)

--- a/src/debugger/breakpoints.jl
+++ b/src/debugger/breakpoints.jl
@@ -1,6 +1,6 @@
-using Juno, Gallium
+using Juno
+using JuliaInterpreter
 import Atom: basepath, handle
-import Gallium: Breakpoint
 
 const bps = Dict{Tuple{String,Int},Breakpoint}()
 

--- a/src/debugger/breakpoints.jl
+++ b/src/debugger/breakpoints.jl
@@ -95,6 +95,20 @@ handle("getbps") do
   end
 end
 
+handle("toggleAllActiveBP") do state
+  with_error_message() do
+    state ? JuliaInterpreter.disable() : JuliaInterpreter.enable()
+    allbreakpoints()
+  end
+end
+
+handle("toggleActiveBP") do file, line
+  with_error_message() do
+    toggleactive(file, line)
+    allbreakpoints()
+  end
+end
+
 function with_error_message(f)
   ret, err = nothing, false
   try
@@ -141,6 +155,16 @@ function location(bp::JuliaInterpreter.BreakpointRef)
   end
 end
 
+function toggleactive(file, line)
+  bps = JuliaInterpreter.breakpoints()
+  for bp in bps
+    bp_file, bp_line = location(bp)
+    if normpath(bp_file) == normpath(file) && bp_line == line
+      bp[].isactive ? JuliaInterpreter.disable(bp) : JuliaInterpreter.enable(bp)
+    end
+  end
+end
+
 function removebreakpoint(file, line)
   bps = JuliaInterpreter.breakpoints()
   removed = false
@@ -152,11 +176,6 @@ function removebreakpoint(file, line)
     end
   end
   removed
-end
-
-function breakpoint(args...)
-  JuliaInterpreter.breakpoint(args...)
-  return
 end
 
 function no_chance_of_breaking()

--- a/src/debugger/debugger.jl
+++ b/src/debugger/debugger.jl
@@ -1,8 +1,13 @@
-isdebugging() = isdefined(Atom, :JunoDebugger) && isdefined(JunoDebugger, :isdebugging) && Atom.JunoDebugger.isdebugging()
+function enter(mod, ex)
+  JunoDebugger.enter(mod, ex)
+end
+
+isdebugging() = JunoDebugger.isdebugging()
 
 module JunoDebugger
 using ..Atom, MacroTools, Lazy, Hiccup
 
+include("breakpoints.jl")
 include("stepper.jl")
 
 end # module

--- a/src/debugger/debugger.jl
+++ b/src/debugger/debugger.jl
@@ -1,5 +1,5 @@
-function enter(mod, ex)
-  JunoDebugger.enter(mod, ex)
+function enter(mod, ex; initial_continue = false)
+  JunoDebugger.enter(mod, ex; initial_continue = initial_continue)
 end
 
 isdebugging() = JunoDebugger.isdebugging()

--- a/src/debugger/debugger.jl
+++ b/src/debugger/debugger.jl
@@ -1,7 +1,7 @@
-isdebugging() = isdefined(Atom, :Debugger) && isdefined(Debugger, :isdebugging) && Atom.Debugger.isdebugging()
+isdebugging() = isdefined(Atom, :JunoDebugger) && isdefined(JunoDebugger, :isdebugging) && Atom.JunoDebugger.isdebugging()
 
-module Debugger
-using ..Atom, MacroTools, ASTInterpreter2, Lazy, Hiccup
+module JunoDebugger
+using ..Atom, MacroTools, Lazy, Hiccup
 
 include("stepper.jl")
 

--- a/src/debugger/load.jl
+++ b/src/debugger/load.jl
@@ -1,5 +1,5 @@
 function enter(mod, ex)
-  !isdefined(Atom, :JunoDebugger) && @eval include(joinpath(dirname($@__FILE__), "debugger.jl"))
+  !isdefined(Atom, :JunoDebugger) && @eval include(joinpath($@__DIR__, "debugger.jl"))
   Base.invokelatest(Atom.JunoDebugger.enter, mod, :($ex))
 end
 

--- a/src/debugger/load.jl
+++ b/src/debugger/load.jl
@@ -1,6 +1,0 @@
-function enter(mod, ex)
-  !isdefined(Atom, :JunoDebugger) && @eval include(joinpath($@__DIR__, "debugger.jl"))
-  Base.invokelatest(Atom.JunoDebugger.enter, mod, :($ex))
-end
-
-isdebugging() = isdefined(Atom, :JunoDebugger) && JunoDebugger.isdebugging()

--- a/src/debugger/load.jl
+++ b/src/debugger/load.jl
@@ -1,6 +1,6 @@
 function enter(mod, ex)
-  !isdefined(Atom, :Debugger) && @eval include(joinpath(dirname($@__FILE__), "debugger.jl"))
-  Base.invokelatest(Atom.Debugger.enter, mod, :($ex))
+  !isdefined(Atom, :JunoDebugger) && @eval include(joinpath(dirname($@__FILE__), "debugger.jl"))
+  Base.invokelatest(Atom.JunoDebugger.enter, mod, :($ex))
 end
 
-isdebugging() = isdefined(Atom, :Debugger) && Debugger.isdebugging()
+isdebugging() = isdefined(Atom, :JunoDebugger) && JunoDebugger.isdebugging()

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -72,6 +72,8 @@ function startdebugging(frame)
           debug_command(frame, :s, true)
         elseif val == :finish
           debug_command(frame, :finish, true)
+        elseif val == :stop
+          return nothing
         elseif val isa Tuple && val[1] == :toline && val[2] isa Int
           method = frame.framecode.scope
           @assert method isa Method
@@ -161,7 +163,7 @@ function debugprompt()
 end
 
 # setup handlers for stepper commands
-for cmd in [:nextline, :stepin, :stepexpr, :finish]
+for cmd in [:nextline, :stepin, :stepexpr, :finish, :stop]
   handle(()->put!(chan[], cmd), string(cmd))
 end
 
@@ -194,7 +196,7 @@ end
 function stack(frame)
   ctx = []
   frame = root(frame)
-  level = -1
+  level = 0
   while frame ≠ nothing
     name = frame.framecode.scope isa Method ? frame.framecode.scope.name : "???"
     file, line = JuliaInterpreter.whereis(frame)

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -179,7 +179,7 @@ function stepto(frame::Frame)
   file, line = JuliaInterpreter.whereis(frame)
   file = Atom.fullpath(string(file))
 
-  @msg stepto(file, line+1, stepview(nextstate(frame)), moreinfo(file, line, frame))
+  @msg stepto(file, line, stepview(nextstate(frame)), moreinfo(file, line, frame))
 end
 stepto(state::DebuggerState) = stepto(state.frame)
 stepto(::Nothing) = debugmode(false)
@@ -228,6 +228,7 @@ function get_code_around(file, line, frame; around = 3)
     lines = readlines(file)
   else
     buf = IOBuffer()
+    line = convert(Int, frame.pc[])
     src = frame.framecode.src
     show(buf, src)
     active_line = convert(Int, frame.pc[])

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -211,11 +211,15 @@ function stack(frame)
   frame = root(frame)
   level = 0
   while frame ≠ nothing
-    name = frame.framecode.scope isa Method ? frame.framecode.scope.name : "???"
+    method = frame.framecode.scope
+
+    name = sprint(show, "text/plain", method)
+    name = replace(name, r" in .* at .*$" => "")
+    name = replace(name, r" where .*$" => "")
+
     file, line = JuliaInterpreter.whereis(frame)
     file = Atom.fullpath(string(file))
     shortpath, _ = Atom.expandpath(file)
-    level += 1
     c = Dict(
       :level => level,
       :name => name,
@@ -225,6 +229,7 @@ function stack(frame)
     )
     push!(ctx, c)
 
+    level += 1
     frame = frame.callee
   end
   reverse(ctx)

--- a/src/profiler/traceur.jl
+++ b/src/profiler/traceur.jl
@@ -1,12 +1,12 @@
 import Traceur
 
-macro trace(ex)
-    :(showtrace(gettrace(() -> $(esc(ex)))))
+function trace(ex, args...)
+    :($(showtrace)($(gettrace)(() -> $(esc(ex)); $(map(esc, args)...))))
 end
 
-function gettrace(f)
+function gettrace(f; kwargs...)
     warns = []
-    Traceur.trace(x -> push!(warns, transformwarn(x)), f)
+    Traceur.trace(x -> push!(warns, transformwarn(x)), f; kwargs...)
     warns
 end
 

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -154,7 +154,7 @@ function evalrepl(mod, line)
     try
       msg("working")
       try
-        ans = Atom.Debugger.interpret(line)
+        ans = Atom.JunoDebugger.interpret(line)
       catch err
         display_error(stderr, err, stacktrace(catch_backtrace()))
       end

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -42,7 +42,7 @@ handle("workspace") do mod
   filter!(n -> !isa(getfield(mod, n), Module), ns)
   contexts = [d(:context => string(mod), :items => map(n -> wsitem(mod, n), ns))]
   if isdebugging()
-    prepend!(contexts, Debugger.contexts())
+    prepend!(contexts, JunoDebugger.contexts())
   end
   return contexts
 end


### PR DESCRIPTION
- [x] Stepping.
- [x] Basic REPL.
- [x] Clean up code a little.
- [x] Restore breakpoint functionality here and in the frontend.
- [ ] Reuse Debugger.jl's REPL (probably impossible right now)
- [ ] Conditional breakpoints.

Needs https://github.com/JunoLab/atom-julia-client/pull/554 and https://github.com/JunoLab/atom-ink/pull/193.