### PR TITLE
Enhance autocompletions

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -85,6 +85,17 @@ function completionsummary(mod, c)
   description(b)
 end
 
+function completionsummary(mod, c::REPLCompletions.ModuleCompletion)
+  mod = c.parent
+  word = c.mod
+  (!Base.isbindingresolved(mod, Symbol(word)) || Base.isdeprecated(mod, Symbol(word))) && return ""
+  getdocs(string(mod), word) |> makedescription
+end
+
+function completionsummary(mod, c::REPLCompletions.KeywordCompletion)
+  getdocs(string(mod), c.keyword) |> makedescription
+end
+
 function completionsummary(mod, c::REPLCompletions.MethodCompletion)
   b = Docs.Binding(mod, Symbol(c.func))
   (!Base.isbindingresolved(mod, Symbol(c.func)) || Base.isdeprecated(mod, Symbol(c.func))) && return ""

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -120,7 +120,7 @@ function makedescription(docs)
     if part isa Markdown.Paragraph
       desc = Markdown.plain(part)
       occursin("No documentation found.", desc) && return ""
-      return strlimit(desc, 100)
+      return strlimit(desc, 200)
     end
   end
 end

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -77,6 +77,7 @@ function returntype(mod, line, c::REPLCompletions.MethodCompletion)
 end
 
 using Base.Docs
+
 function completionsummary(mod, c)
   ct = Symbol(REPLCompletions.completion_text(c))
   (!Base.isbindingresolved(mod, ct) || Base.isdeprecated(mod, ct)) && return ""
@@ -90,13 +91,18 @@ function completionsummary(mod, c::REPLCompletions.MethodCompletion)
   description(b, Base.tuple_type_tail(c.method.sig))
 end
 
-using Markdown
 function description(binding, sig = Union{})
   docs = try
     Docs.doc(binding, sig)
   catch err
     ""
   end
+  makedescription(docs)
+end
+
+using Markdown
+
+function makedescription(docs)
   docs isa Markdown.MD || return ""
   md = CodeTools.flatten(docs).content
   for part in md
@@ -142,8 +148,8 @@ function completiontype(line, x, mod)
 end
 
 function completiontype(x, mod::Module, ct::AbstractString)
-  x <: Module   ? "module"   :
-  x <: DataType ? "type"     :
+  x <: Module ? "module" :
+  x <: DataType ? "type" :
   x isa Type{<:Type} ? "type" :
   typeof(x) == UnionAll ? "type" :
   x <: Function ? "function" :

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -94,8 +94,8 @@ end
 
 function completionsummary(mod, c::REPLCompletions.MethodCompletion)
   ct = Symbol(c.func)
+  !cangetdocs(mod, ct) && return ""
   b = Docs.Binding(mod, ct)
-  !cangetdocs(mod, ct) && return ""  
   description(b, Base.tuple_type_tail(c.method.sig))
 end
 


### PR DESCRIPTION
https://julialang.slack.com/archives/C7JT7HQAD/p1564337316096500

Basically this enables descriptions for non-exported methods of modules and keywords: E.g.:
- `Juno.@trace`, `Atom.handle` (even in `Main`)
- `begin`, ...