### PR TITLE
Drop methodtable in datatip

### DIFF
--- a/src/datatip.jl
+++ b/src/datatip.jl
@@ -1,10 +1,3 @@
-"""
-Regex that matches for a Julia documentation text when there is no binding exists
-for the target word.
-Refered to https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/docview.jl#L152.
-"""
-const nobinding_regex = r"No documentation found.\n\nBinding `.*` does not exist.\n"
-
 handle("datatip") do data
   @destruct [mod || "Main", word] = data
   docs = @errs getdocs(mod, word)
@@ -12,16 +5,18 @@ handle("datatip") do data
   docs isa EvalError && return Dict(:error => true)
   occursin(nobinding_regex, string(docs)) && return Dict(:novariable => true)
 
-  mtable = try getmethods(mod, word)
-    catch e
-      []
-    end
-
   Dict(:error   => false,
-       :strings => makedatatip(docs, word, mtable))
+       :strings => makedatatip(docs))
 end
 
-function makedatatip(docs, word, mtable)
+"""
+Regex that matches for a Julia documentation text when there is no binding exists
+for the target word.
+Adapted from https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/docview.jl#L152.
+"""
+const nobinding_regex = r"No documentation found.\n\nBinding `.*` does not exist.\n"
+
+function makedatatip(docs)
   # @FIXME?: Separates code blocks from the other markdown texts in order to
   #          render them as code snippet text by atom-ide-ui's datatip service.
   #          Setting up functions to deconstruct each `Markdown.MD.content`
@@ -35,7 +30,6 @@ function makedatatip(docs, word, mtable)
     processmdcode!(code, datatips)
     processmdtext!(text, datatips)
   end
-  processmethodtable!(word, mtable, datatips)
 
   datatips
 end
@@ -44,6 +38,7 @@ end
 Regex to match code blocks from markdown texts.
 """
 const codeblock_regex = r"```((?!```).)*?```"s
+
 # Extract only code blocks from Markdown.MD
 function searchcodeblocks(docs)
   codeblocks = []
@@ -69,22 +64,4 @@ end
 function processmdcode!(code, datatips)
   push!(datatips, Dict(:type  => :snippet,
                        :value => code))
-end
-
-function processmethodtable!(word, mtable, datatips)
-  isempty(mtable) && return
-
-  header = "\n***\n`$(word)` has **$(length(mtable))** methods\n"
-
-  body = map(mtable) do m
-    mstring = string(m)
-    text = mstring[1:match(r" at ", mstring).offset + 3]
-    isbase = m.module === Base || parentmodule(m.module) === Base
-    file = isbase ? basepath(string(m.file)) : m.file
-    # @NOTE: Datatip service component can't handle links to file paths.
-    "- $(text)$(file):$(m.line)"
-  end |> lists -> join(lists, "\n")
-
-  push!(datatips, Dict(:type  => :markdown,
-                       :value => header * body))
 end

--- a/src/datatip.jl
+++ b/src/datatip.jl
@@ -1,3 +1,10 @@
+#=
+@FIXME?
+If we come to be able to use our full-featured components in atom-julia-client
+for datatips, we may want to append method tables again.
+Ref: https://github.com/JunoLab/atom-julia-client/blob/master/lib/runtime/datatip.js#L3-L9
+=#
+
 handle("datatip") do data
   @destruct [mod || "Main", word] = data
   docs = @errs getdocs(mod, word)
@@ -17,10 +24,10 @@ Adapted from https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/docv
 const nobinding_regex = r"No documentation found.\n\nBinding `.*` does not exist.\n"
 
 function makedatatip(docs)
-  # @FIXME?: Separates code blocks from the other markdown texts in order to
-  #          render them as code snippet text by atom-ide-ui's datatip service.
-  #          Setting up functions to deconstruct each `Markdown.MD.content`
-  #          into an appropriate markdown string might be preferred.
+  # Separates code blocks from the other markdown texts in order to render  them
+  # as code snippet text by atom-ide-ui's datatip service.
+  # Setting up functions to deconstruct each `Markdown.MD.content` into
+  # an appropriate markdown string might be preferred.
   texts = split(string(docs), codeblock_regex)
   codes = searchcodeblocks(docs)
 


### PR DESCRIPTION
I would like to drop method tables in datatip, since it would look rather verbose and useless since atom-ide-ui/datatip can't handle links in `markedStrings` anyways.