### PR TITLE
Avoid error on `changeREPLprompt` on REPL startup

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -47,7 +47,7 @@ handle("validatepath") do uri
   return isfile′(fullREPLpath(uri)[1])
 end
 
-juliaprompt = "julia> "
+const juliaprompt = "julia> "
 
 handle("resetprompt") do linebreak
   isREPL() || return
@@ -106,9 +106,13 @@ function changeREPLprompt(prompt; color = :green, write = true)
   main_mode = get_main_mode()
   main_mode.prompt = prompt
   main_mode.prompt_prefix = color isa Symbol ?
-    string(first(split(sprint(io -> printstyled(IOContext(io, :color => true), " ", color=color)), ' '))) :
+    sprint() do io
+      printstyled(IOContext(io, :color => true), " ", color=color)
+    end |> split |> first |> string :
     color
-  if Base.active_repl.mistate.current_mode == main_mode && write
+  if Base.active_repl.mistate isa REPL.LineEdit.MIState &&
+     Base.active_repl.mistate.current_mode == main_mode &&
+     write
     print(stdout, "\e[1K\r")
     REPL.LineEdit.write_prompt(stdout, main_mode)
   end


### PR DESCRIPTION
Avoid error:
```
Julia Client – Internal Error

type Nothing has no field current_mode
getproperty(::Any, ::Symbol) at sysimg.jl:18
#changeREPLprompt#167(::Symbol, ::Bool, ::Function, ::String) at repl.jl:111
changeREPLprompt at repl.jl:102 [inlined]
(::getfield(Atom, Symbol("##157#158")))(::String) at repl.jl:23
handlemsg(::String, ::String) at comm.jl:164
(::getfield(Atom, Symbol("##19#21")){Array{Any,1}})() at task.jl:259
```

(Just for those who use the `consoleOptions.terminal` setting)