### PR TITLE
Better completions

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -1,7 +1,3 @@
-matchesprefix(c::AbstractString, pre::AbstractString) = isempty(pre) || lowercase(c[1]) == lowercase(pre[1])
-matchesprefix(c::Dict, pre::AbstractString) = matchesprefix(c[:text], pre)
-matchesprefix(c, ::Nothing) = true
-
 handle("completions") do data
   @destruct [path || nothing, mod || "Main", line, force] = data
   withpath(path) do
@@ -16,6 +12,7 @@ handle("completions") do data
 end
 
 using REPL.REPLCompletions
+
 function basecompletionadapter(line, mod, force)
   comps, replace, shouldcomplete = try
     REPL.REPLCompletions.completions(line, lastindex(line), mod)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -134,12 +134,10 @@ function makedescription(docs)
   end
 end
 
-function completionmodule(mod, c)
-  c isa REPLCompletions.ModuleCompletion ? string(c.parent) :
-    c isa REPLCompletions.MethodCompletion ? string(c.method.module) :
-    c isa REPLCompletions.KeywordCompletion ? "Base" :
-    string(mod)
-end
+completionmodule(mod, c) = string(mod)
+completionmodule(mod, c::REPLCompletions.ModuleCompletion) = string(c.parent)
+completionmodule(mod, c::REPLCompletions.MethodCompletion) = string(c.method.module)
+completionmodule(mod, c::REPLCompletions.KeywordCompletion) = "Base"
 
 function completiontype(line, x, mod)
   ct = REPLCompletions.completion_text(x)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -21,9 +21,9 @@ function basecompletionadapter(line, mod, force)
     [], 1:0, false
   end
 
-  # Suppress completions if there are too many of them
-  # @NOTE: `complete_symbol("", ffunc, context_module)` returns ≥1000 completions as of v1.1
-  # @TODO: Checking whether `line` is valid text to be completed in atom-julia-client
+  # Suppress completions if there are too many of them unless activated manually
+  # @TODO: Checking whether `line` is a valid text to be completed in atom-julia-client
+  #        in advance and drop this check
   (!force && length(comps) > 500) && begin
     comps = []
     replace = 1:0
@@ -47,10 +47,10 @@ function basecompletionadapter(line, mod, force)
 end
 
 function completion(mod, line, c)
-  return Dict(:type => completiontype(line, c, mod),
-              :rightLabel => completionmodule(mod, c),
-              :leftLabel => returntype(mod, line, c),
-              :text => completiontext(c),
+  return Dict(:type        => completiontype(line, c, mod),
+              :rightLabel  => completionmodule(mod, c),
+              :leftLabel   => returntype(mod, line, c),
+              :text        => completiontext(c),
               :description => completionsummary(mod, c))
 end
 
@@ -147,7 +147,7 @@ function completiontype(line, x, mod)
   if x isa REPLCompletions.ModuleCompletion
     ct == "Vararg" && return ""
     t, f = try
-      parsed = Meta.parse(ct, raise=false, depwarn=false)
+      parsed = Meta.parse(ct, raise = false, depwarn = false)
       REPLCompletions.get_type(parsed, x.parent)
     catch e
       @error e
@@ -169,12 +169,13 @@ end
 
 function completiontype(x, mod::Module, ct::AbstractString)
   x <: Module ? "module" :
-  x <: DataType ? "type" :
-  x isa Type{<:Type} ? "type" :
-  typeof(x) == UnionAll ? "type" :
-  x <: Function ? "function" :
-  x <: Tuple ? "tuple" :
-  isconst(mod, Symbol(ct)) ? "constant" : "object"
+    x <: DataType ? "type" :
+    x isa Type{<:Type} ? "type" :
+    typeof(x) == UnionAll ? "type" :
+    x <: Function ? "function" :
+    x <: Tuple ? "tuple" :
+    isconst(mod, Symbol(ct)) ? "constant" :
+    "object"
 end
 
 handle("cacheCompletions") do mod

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -1,7 +1,7 @@
 handle("completions") do data
   @destruct [path || nothing, mod || "Main", line, force] = data
   withpath(path) do
-    m = getthing(mod)
+    m = getmodule′(mod)
     m = isa(m, Module) ? m : Main
 
     cs, pre = basecompletionadapter(line, m, force)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -6,8 +6,8 @@ handle("completions") do data
 
     cs, pre = basecompletionadapter(line, m, force)
 
-    d(:completions        => cs,
-      :prefix             => string(pre))
+    d(:completions => cs,
+      :prefix      => string(pre))
   end
 end
 
@@ -57,14 +57,14 @@ end
 completiontext(x) = REPLCompletions.completion_text(x)
 completiontext(x::REPLCompletions.PathCompletion) = rstrip(REPLCompletions.completion_text(x), '"')
 completiontext(x::REPLCompletions.DictCompletion) = rstrip(REPLCompletions.completion_text(x), [']', '"'])
-function completiontext(x::REPLCompletions.MethodCompletion)
+completiontext(x::REPLCompletions.MethodCompletion) = begin
   ct = REPLCompletions.completion_text(x)
   ct = match(r"^(.*) in .*$", ct)
   ct isa Nothing ? ct : ct[1]
 end
 
 returntype(mod, line, c) = ""
-function returntype(mod, line, c::REPLCompletions.MethodCompletion)
+returntype(mod, line, c::REPLCompletions.MethodCompletion) = begin
   m = c.method
   atypes = m.sig
   sparams = m.sparam_syms
@@ -77,6 +77,11 @@ function returntype(mod, line, c::REPLCompletions.MethodCompletion)
   inf in (nothing, Any, Union{}) && return ""
   typ = string(inf)
 
+  strlimit(typ, 20)
+end
+returntype(mod, line, c::REPLCompletions.PropertyCompletion) = begin
+  prop = getproperty(c.value, c.property)
+  typ = string(typeof(prop))
   strlimit(typ, 20)
 end
 

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -135,7 +135,10 @@ function makedescription(docs)
 end
 
 function completionmodule(mod, c)
-  c isa REPLCompletions.ModuleCompletion ? string(c.parent) : string(mod)
+  c isa REPLCompletions.ModuleCompletion ? string(c.parent) :
+    c isa REPLCompletions.MethodCompletion ? string(c.method.module) :
+    c isa REPLCompletions.KeywordCompletion ? "Base" :
+    string(mod)
 end
 
 function completiontype(line, x, mod)


### PR DESCRIPTION
- Ref: https://julialang.slack.com/archives/C7JT7HQAD/p1565114009249700

In short, I want to suppress too many completions from texts like `[|`, `(|`, or `&|` (where `|` represents cursor position), since those over 1000 completions often takes much time and worsen coding experience.

I think it would be better if we could handle these cases in front end (i.e. atom-julia-client) in terms of efficiency, but I found the corner cases can be a lot and handling them in backend like this is fairly easy and simple.