### PR TITLE
consistent types

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -172,6 +172,10 @@ function completiontype(line, c, mod)
     "variable"
 end
 
+completiontype(line, ::REPLCompletions.DictCompletion, mod) = "key" # can be fallen into "macro" otherwise
+
+ismacro(ct::AbstractString) = startswith(ct, '@') || endswith(ct, '"')
+
 function completiontype(t, mod::Module, ct::AbstractString)
   t <: Function ? "function" :
     t <: DataType ? "type" :
@@ -184,8 +188,6 @@ function completiontype(t, mod::Module, ct::AbstractString)
     isconst(mod, Symbol(ct)) ? "constant" :
     "variable"
 end
-
-ismacro(ct::AbstractString) = startswith(ct, '@') || endswith(ct, '"')
 
 completionicon(c) = ""
 completionicon(c::REPLCompletions.ModuleCompletion) = begin

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -147,7 +147,7 @@ completionmodule(mod, ::REPLCompletions.PathCompletion) = ""
 
 completiontype(line, c, mod) = begin
   ct = REPLCompletions.completion_text(c)
-  ismacro(ct) && return "function"
+  ismacro(ct) && return "snippet"
   startswith(ct, ':') && return "tag"
 
   if c isa REPLCompletions.ModuleCompletion

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -63,11 +63,13 @@ completiontext(x::REPLCompletions.MethodCompletion) = begin
   ct isa Nothing ? ct : ct[1]
 end
 
+using JuliaInterpreter: sparam_syms
+
 returntype(mod, line, c) = ""
 returntype(mod, line, c::REPLCompletions.MethodCompletion) = begin
   m = c.method
   atypes = m.sig
-  sparams = m.sparam_syms
+  sparams = Core.svec(sparam_syms(m)...)
   wa = Core.Compiler.Params(typemax(UInt))  # world age
   inf = try
     Core.Compiler.typeinf_type(m, atypes, sparams, wa)

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -422,7 +422,7 @@ end
 
 struct Undefined end
 @render Inline u::Undefined span(".fade", "<undefined>")
-wsicon(name, ::Undefined) = "icon-circle-slash"
+wsicon(mod, name, ::Undefined) = "icon-circle-slash"
 
 handle("setStackLevel") do level
   with_error_message() do

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -1,7 +1,7 @@
 using JuliaInterpreter: pc_expr, moduleof, linenumber, extract_args, debug_command,
                         root, caller, whereis, get_return, nstatements, @lookup, Frame
 import JuliaInterpreter
-import ..Atom: fullpath, handle, @msg, wsitem, Inline, EvalError, Console, display_error
+import ..Atom: fullpath, handle, @msg, wsitem, Inline, wsicon, EvalError, Console, display_error
 import Juno: Row, Tree
 import REPL
 using Media
@@ -411,16 +411,18 @@ end
 function localvars(frame)
   vars = JuliaInterpreter.locals(frame)
   items = []
+  scope = frame.framecode.scope
+  mod = scope isa Module ? scope : scope.module
   for v in vars
       v.name == Symbol("#self#") && (isa(v.value, Type) || sizeof(v.value) == 0) && continue
-      push!(items, wsitem(String(v.name), v.value))
+      push!(items, wsitem(mod, v.name, v.value))
   end
-  return items
+  items
 end
 
 struct Undefined end
 @render Inline u::Undefined span(".fade", "<undefined>")
-Atom.wsicon(::Undefined) = "icon-circle-slash"
+wsicon(name, ::Undefined) = "icon-circle-slash"
 
 handle("setStackLevel") do level
   with_error_message() do

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -1,7 +1,7 @@
 using JuliaInterpreter: pc_expr, moduleof, linenumber, extract_args, debug_command,
                         root, caller, whereis, get_return, nstatements, @lookup, Frame
 import JuliaInterpreter
-import ..Atom: fullpath, handle, @msg, wsitem, Inline, wsicon, EvalError, Console, display_error
+import ..Atom: fullpath, handle, @msg, wsitem, Inline, EvalError, Console, display_error
 import Juno: Row, Tree
 import REPL
 using Media
@@ -419,10 +419,6 @@ function localvars(frame)
   end
   items
 end
-
-struct Undefined end
-@render Inline u::Undefined span(".fade", "<undefined>")
-wsicon(mod, name, ::Undefined) = "icon-circle-slash"
 
 handle("setStackLevel") do level
   with_error_message() do

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -67,6 +67,13 @@ function modulesymbols(mod)
   sort(syms, by = x -> x.name)[1:min(100, length(syms))]
 end
 
+using Logging: with_logger, current_logger
+using .Progress: JunoProgressLogger
+
 handle("regenerateCache") do
-  DocSeeker.createdocsdb()
+  Base.CoreLogging.with_logger(Atom.Progress.JunoProgressLogger(Base.CoreLogging.current_logger())) do
+    @errs begin
+      DocSeeker.createdocsdb()
+    end
+  end
 end

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -13,6 +13,16 @@ end
 function renderitem(x)
   r = Dict(f => getfield(x, f) for f in fieldnames(DocSeeker.DocObj))
   r[:html] = view(renderMD(x.html))
+
+  mod = getmodule′(x.mod)
+  name = Symbol(x.name)
+  r[:typ], r[:icon] = if name ∈ keys(Docs.keywords)
+    "keyword", "k"
+  else
+    val = getfield(mod, name)
+    wstype(mod, name, val), wsicon(mod, name, val)
+  end
+  r[:nativetype] = x.typ
   r
 end
 

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -72,8 +72,6 @@ using .Progress: JunoProgressLogger
 
 handle("regenerateCache") do
   Base.CoreLogging.with_logger(Atom.Progress.JunoProgressLogger(Base.CoreLogging.current_logger())) do
-    @errs begin
-      DocSeeker.createdocsdb()
-    end
+    @errs DocSeeker.createdocsdb()
   end
 end

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -16,13 +16,14 @@ function renderitem(x)
 
   mod = getmodule′(x.mod)
   name = Symbol(x.name)
-  r[:typ], r[:icon] = if name ∈ keys(Docs.keywords)
-    "keyword", "k"
-  else
+  r[:typ], r[:icon], r[:nativetype] = if name ∈ keys(Docs.keywords)
+    "keyword", "k", x.typ
+  elseif isdefined(mod, name)
     val = getfield(mod, name)
-    wstype(mod, name, val), wsicon(mod, name, val)
+    wstype(mod, name, val), wsicon(mod, name, val), x.typ
+  else # not loaded - DocSeeker can show docs for non-loaded packages via `createdocsdb()`
+    "ignored", "icon-circle-slash", "Not loaded"
   end
-  r[:nativetype] = x.typ
   r
 end
 

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -1,48 +1,46 @@
-ismacro(f::Function) = startswith(string(methods(f).mt.name), "@")
+handle("workspace") do data
+  @destruct [mod, hide || true] = data
+  mod = getmodule′(mod)
+  ns = Symbol.(CodeTools.filtervalid(names(mod; all = true)))
+  filter!(ns) do n
+    (!hide || !Base.isdeprecated(mod, n)) && isdefined(mod, n) && n != Symbol(mod)
+  end
+  contexts = [d(:context => string(mod), :items => map(n -> wsitem(mod, n), ns))]
+  isdebugging() && prepend!(contexts, JunoDebugger.contexts())
+  contexts
+end
 
-wstype(x) = ""
-wstype(::Module) = "module"
-wstype(f::Function) = "function"
-wstype(::Type) = "type"
-wstype(::Expr) = "mixin"
-wstype(::Symbol) = "tag"
-wstype(::AbstractString) = "property"
-wstype(::Number) = "constant"
-wstype(::Exception) = "tag"
-
-wsicon(x) = ""
-wsicon(f::Function) = ismacro(f) ? "icon-mention" : ""
-wsicon(::AbstractArray) = "icon-file-binary"
-wsicon(::AbstractVector) = "icon-list-ordered"
-wsicon(::AbstractString) = "icon-quote"
-wsicon(::Expr) = "icon-code"
-wsicon(::Symbol) = "icon-code"
-wsicon(::Exception) = "icon-bug"
-wsicon(::Number) = "n"
-
-wsnamed(name, val) = false
-wsnamed(name, f::Function) = name == methods(f).mt.name
-wsnamed(name, m::Module) = name == module_name(m)
-wsnamed(name, T::DataType) = name == Symbol(T.name)
-
-function wsitem(name, val)
+wsitem(mod::Module, name) = begin
+  val = getfield(mod, name)
   d(:name  => name,
     :value => render′(Inline(), val),
-    :type  => wstype(val),
-    :icon  => wsicon(val))
+    :type  => wstype(mod, name, val),
+    :icon  => wsicon(mod, name, val))
 end
 
-wsitem(mod::Module, name::Symbol) = wsitem(name, getfield(mod, name))
-
-handle("workspace") do mod
-  mod = getmodule′(mod)
-  ns = filter!(x->!Base.isdeprecated(mod, x), Symbol.(CodeTools.filtervalid(names(mod, all=true))))
-  filter!(n -> isdefined(mod, n), ns)
-  # TODO: only filter out imported modules
-  filter!(n -> !isa(getfield(mod, n), Module), ns)
-  contexts = [d(:context => string(mod), :items => map(n -> wsitem(mod, n), ns))]
-  if isdebugging()
-    prepend!(contexts, JunoDebugger.contexts())
-  end
-  return contexts
+wstype(mod, name, val) = begin
+  val isa Function ? "function" :
+    val isa Type ? "type" :
+    val isa Module ? "module" :
+    val isa Expr ? "mixin" :
+    val isa Symbol ? "tag" :
+    val isa Exception ? "mixin" :
+    isconst(mod, name) ? "constant" : "variable"
 end
+
+wsicon(mod, name, val) = begin
+  val isa Function ? (ismacro(val) ? "icon-mention" : "λ") :
+    val isa Type ? "T" :
+    val isa Module ? "icon-package" :
+    val isa Number ? "n" :
+    val isa AbstractVector ? "icon-list-ordered" :
+    val isa AbstractArray ? "icon-file-binary" :
+    val isa AbstractString ? "icon-quote" :
+    val isa Regex ? "icon-quote" :
+    val isa Expr ? "icon-code" :
+    val isa Symbol ? "icon-code" :
+    val isa Exception ? "icon-bug" :
+    isconst(mod, name) ? "c" : "v"
+end
+
+ismacro(f::Function) = startswith(string(methods(f).mt.name), "@")

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -25,31 +25,26 @@ end
 @NOTE: `wstype` and `wsicon` are also used for completions / docs
 =#
 
-wstype(mod, name, val) = begin
-  val isa Function ? "function" :
-    val isa Type ? "type" :
-    val isa Module ? "module" :
-    val isa Expr ? "mixin" :
-    val isa Symbol ? "tag" :
-    val isa Exception ? "mixin" :
-    isconst(mod, name) ? "constant" :
-    "variable"
-end
+wstype(mod, name, val) = isconst(mod, name) ? "constant" : "variable"
+wstype(mod, name, val::Function) = ismacro(val) ? "snippet" : "function"
+wstype(mod, name, ::Type) = "type"
+wstype(mod, name, ::Module) = "module"
+wstype(mod, name, ::Expr) = "mixin"
+wstyep(mod, name, ::Symbol) = "tag"
+wstype(mod, name, ::Exception) = "mixin"
 
-wsicon(mod, name, val) = begin
-  val isa Function ? (ismacro(val) ? "icon-mention" : "λ") :
-    val isa Type ? "T" :
-    val isa Module ? "icon-package" :
-    val isa Number ? "n" :
-    val isa AbstractVector ? "icon-list-ordered" :
-    val isa AbstractArray ? "icon-file-binary" :
-    val isa AbstractDict ? "icon-list-unordered" :
-    val isa AbstractString ? "icon-quote" :
-    val isa Regex ? "icon-quote" :
-    val isa Expr ? "icon-code" :
-    val isa Symbol ? "icon-code" :
-    val isa Exception ? "icon-bug" :
-    isconst(mod, name) ? "c" : "v"
-end
+wsicon(mod, name, val) = isconst(mod, name) ? "c" : "v"
+wsicon(mod, name, val::Function) = ismacro(val) ? "icon-mention" : "λ"
+wsicon(mod, name, ::Type) = "T"
+wsicon(mod, name, ::Module) = "icon-package"
+wsicon(mod, name, ::Number) = "n"
+wsicon(mod, name, ::AbstractVector) = "icon-list-ordered"
+wsicon(mod, name, ::AbstractArray) = "icon-file-binary"
+wsicon(mod, name, ::AbstractDict) = "icon-list-unordered"
+wsicon(mod, name, ::AbstractString) = "icon-quote"
+wsicon(mod, name, ::Regex) = "icon-quote"
+wsicon(mod, name, ::Expr) = "icon-code"
+wsicon(mod, name, ::Symbol) = "icon-code"
+wsicon(mod, name, ::Exception) = "icon-bug"
 
 ismacro(f::Function) = startswith(string(methods(f).mt.name), "@")

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -26,15 +26,12 @@ end
 =#
 
 wstype(mod, name, val) = begin
-  type = typeof(val)
-  type <: Function ? "function" :
-    type <: DataType ? "type" :
-    type isa Type{<:Type} ? "type" :
-    typeof(type) == UnionAll ? "type" :
-    type <: Module ? "module" :
-    type <: Expr ? "mixin" :
-    type <: Symbol ? "tag" :
-    type <: Exception ? "mixin" :
+  val isa Function ? "function" :
+    val isa Type ? "type" :
+    val isa Module ? "module" :
+    val isa Expr ? "mixin" :
+    val isa Symbol ? "tag" :
+    val isa Exception ? "mixin" :
     isconst(mod, name) ? "constant" :
     "variable"
 end

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -1,9 +1,8 @@
-handle("workspace") do data
-  @destruct [mod, hide || true] = data
+handle("workspace") do mod
   mod = getmodule′(mod)
   ns = Symbol.(CodeTools.filtervalid(names(mod; all = true)))
   filter!(ns) do n
-    (!hide || !Base.isdeprecated(mod, n)) && isdefined(mod, n) && n != Symbol(mod)
+    !Base.isdeprecated(mod, n) && isdefined(mod, n) && n != Symbol(mod)
   end
   contexts = [d(:context => string(mod), :items => map(n -> wsitem(mod, n), ns))]
   isdebugging() && prepend!(contexts, JunoDebugger.contexts())

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -10,12 +10,16 @@ handle("workspace") do data
   contexts
 end
 
-wsitem(mod::Module, name) = begin
+wsitem(mod, name) = begin
   val = getfield(mod, name)
-  d(:name  => name,
-    :value => render′(Inline(), val),
-    :type  => wstype(mod, name, val),
-    :icon  => wsicon(mod, name, val))
+  wsitem(mod, name, val)
+end
+wsitem(mod, name, val) = begin
+  d(:name       => name,
+    :value      => render′(Inline(), val),
+    :nativetype => DocSeeker.determinetype(mod, name),
+    :type       => wstype(mod, name, val),
+    :icon       => wsicon(mod, name, val))
 end
 
 wstype(mod, name, val) = begin

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -21,14 +21,22 @@ wsitem(mod, name, val) = begin
     :icon       => wsicon(mod, name, val))
 end
 
+#=
+@NOTE: `wstype` and `wsicon` are also used for completions / docs
+=#
+
 wstype(mod, name, val) = begin
-  val isa Function ? "function" :
-    val isa Type ? "type" :
-    val isa Module ? "module" :
-    val isa Expr ? "mixin" :
-    val isa Symbol ? "tag" :
-    val isa Exception ? "mixin" :
-    isconst(mod, name) ? "constant" : "variable"
+  type = typeof(val)
+  type <: Function ? "function" :
+    type <: DataType ? "type" :
+    type isa Type{<:Type} ? "type" :
+    typeof(type) == UnionAll ? "type" :
+    type <: Module ? "module" :
+    type <: Expr ? "mixin" :
+    type <: Symbol ? "tag" :
+    type <: Exception ? "mixin" :
+    isconst(mod, name) ? "constant" :
+    "variable"
 end
 
 wsicon(mod, name, val) = begin
@@ -38,6 +46,7 @@ wsicon(mod, name, val) = begin
     val isa Number ? "n" :
     val isa AbstractVector ? "icon-list-ordered" :
     val isa AbstractArray ? "icon-file-binary" :
+    val isa AbstractDict ? "icon-list-unordered" :
     val isa AbstractString ? "icon-quote" :
     val isa Regex ? "icon-quote" :
     val isa Expr ? "icon-code" :


### PR DESCRIPTION
## purpose

addressing: https://github.com/JunoLab/atom-julia-client/blob/master/lib/runtime/completions.js#L4
- we basically use `wstype` and `wsicon` for all the type/icon definitions of workspace/completions/docs
  * simplify code a lot
  * special cases like `keyword` and workspaces in debugger are gracefully handled, I believe
- all these tasks are handled by backend, which makes code simpler I believe
- introduced constant-ness check for all of them: every objects has either `variable` or `constant` type
- added some additional icon definitions for `Regex` and so

![Screenshot 2019-08-18 23 55 59](https://user-images.githubusercontent.com/40514306/63226379-dda11780-c213-11e9-8449-0117f70633e1.png)

## refs

corresponding PRs:
- https://github.com/JunoLab/atom-julia-client/pull/592
- https://github.com/JunoLab/atom-ink/pull/213