### PR TITLE
Handle undefined

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -160,7 +160,7 @@ completiontype(line, c, mod) = begin
       @error e
       nothing, false
     end
-    return found ? completiontype(val, mod, ct) : "variable"
+    return found ? completiontype(val, mod, ct) : "ignored"
   end
   c isa REPLCompletions.KeywordCompletion ? "keyword" :
     c isa REPLCompletions.PathCompletion ? "path" :
@@ -177,9 +177,10 @@ ismacro(ct::AbstractString) = startswith(ct, '@') || endswith(ct, '"')
 
 completionicon(c) = ""
 completionicon(c::REPLCompletions.ModuleCompletion) = begin
+  ismacro(c.mod) && return "icon-mention"
   mod = c.parent
   name = Symbol(c.mod)
-  val = getfield(mod, name)
+  val = getfield′′(mod, name)
   wsicon(mod, name, val)
 end
 completionicon(::REPLCompletions.PathCompletion) = "icon-file"

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -14,7 +14,7 @@ using REPL.REPLCompletions
 
 function basecompletionadapter(line, mod, force)
   comps, replace, shouldcomplete = try
-    REPL.REPLCompletions.completions(line, lastindex(line), mod)
+    completions(line, lastindex(line), mod)
   catch err
     # might error when e.g. type inference fails
     [], 1:0, false
@@ -54,11 +54,11 @@ function completion(mod, line, c)
               :description => completionsummary(mod, c))
 end
 
-completiontext(x) = REPLCompletions.completion_text(x)
-completiontext(x::REPLCompletions.PathCompletion) = rstrip(REPLCompletions.completion_text(x), '"')
-completiontext(x::REPLCompletions.DictCompletion) = rstrip(REPLCompletions.completion_text(x), [']', '"'])
+completiontext(x) = completion_text(x)
+completiontext(x::REPLCompletions.PathCompletion) = rstrip(completion_text(x), '"')
+completiontext(x::REPLCompletions.DictCompletion) = rstrip(completion_text(x), [']', '"'])
 completiontext(x::REPLCompletions.MethodCompletion) = begin
-  ct = REPLCompletions.completion_text(x)
+  ct = completion_text(x)
   ct = match(r"^(.*) in .*$", ct)
   ct isa Nothing ? ct : ct[1]
 end
@@ -91,7 +91,7 @@ returntype(mod, line, ::REPLCompletions.PathCompletion) = "Path"
 using Base.Docs
 
 completionsummary(mod, c) = begin
-  ct = Symbol(REPLCompletions.completion_text(c))
+  ct = Symbol(completion_text(c))
   !cangetdocs(mod, ct) && return ""
   b = Docs.Binding(mod, ct)
   description(b)
@@ -146,7 +146,7 @@ completionmodule(mod, ::REPLCompletions.KeywordCompletion) = "Base"
 completionmodule(mod, ::REPLCompletions.PathCompletion) = ""
 
 completiontype(line, c, mod) = begin
-  ct = REPLCompletions.completion_text(c)
+  ct = completion_text(c)
   ismacro(ct) && return "snippet"
   startswith(ct, ':') && return "tag"
 

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -18,11 +18,11 @@ function renderitem(x)
   name = Symbol(x.name)
   r[:typ], r[:icon], r[:nativetype] = if name ∈ keys(Docs.keywords)
     "keyword", "k", x.typ
-  elseif isdefined(mod, name)
-    val = getfield(mod, name)
-    wstype(mod, name, val), wsicon(mod, name, val), x.typ
-  else # not loaded - DocSeeker can show docs for non-loaded packages via `createdocsdb()`
-    "ignored", "icon-circle-slash", "Not loaded"
+  else
+    val = getfield′′(mod, name)
+    # @NOTE: DocSeeker can show docs for non-loaded packages via `createdocsdb()`
+    nativetype = val isa Undefined ? "Undefined or not loaded yet" : x.typ
+    wstype(mod, name, val), wsicon(mod, name, val), nativetype
   end
   r
 end

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -54,6 +54,7 @@ wsicon(mod, name, ::Regex) = "icon-quote"
 wsicon(mod, name, ::Expr) = "icon-code"
 wsicon(mod, name, ::Symbol) = "icon-code"
 wsicon(mod, name, ::Exception) = "icon-bug"
+wsicon(mod, name, ::Nothing) = "icon-check"
 wsicon(mod, name, ::Undefined) = "icon-circle-slash"
 
 ismacro(f::Function) = startswith(string(methods(f).mt.name), "@")

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -2,7 +2,7 @@ handle("workspace") do mod
   mod = getmodule′(mod)
   ns = Symbol.(CodeTools.filtervalid(names(mod; all = true)))
   filter!(ns) do n
-    !Base.isdeprecated(mod, n) && isdefined(mod, n) && n != Symbol(mod)
+    !Base.isdeprecated(mod, n) && n != Symbol(mod)
   end
   contexts = [d(:context => string(mod), :items => map(n -> wsitem(mod, n), ns))]
   isdebugging() && prepend!(contexts, JunoDebugger.contexts())
@@ -10,16 +10,23 @@ handle("workspace") do mod
 end
 
 wsitem(mod, name) = begin
-  val = getfield(mod, name)
+  val = getfield′′(mod, name)
   wsitem(mod, name, val)
 end
 wsitem(mod, name, val) = begin
   d(:name       => name,
     :value      => render′(Inline(), val),
-    :nativetype => DocSeeker.determinetype(mod, name),
+    :nativetype => nativetype(mod, name, val),
     :type       => wstype(mod, name, val),
     :icon       => wsicon(mod, name, val))
 end
+
+# handle undefineds
+struct Undefined end
+getfield′′(mod, name) = isdefined(mod, name) ? getfield(mod, name) : Undefined()
+@render Inline val::Undefined span(".fade", "<undefined>")
+nativetype(mod, name, val) = DocSeeker.determinetype(mod, name)
+nativetype(mod, name, ::Undefined) = "Undefined"
 
 #=
 @NOTE: `wstype` and `wsicon` are also used for completions / docs
@@ -32,6 +39,7 @@ wstype(mod, name, ::Module) = "module"
 wstype(mod, name, ::Expr) = "mixin"
 wstype(mod, name, ::Symbol) = "tag"
 wstype(mod, name, ::Exception) = "mixin"
+wstype(mod, name, ::Undefined) = "ignored"
 
 wsicon(mod, name, val) = isconst(mod, name) ? "c" : "v"
 wsicon(mod, name, val::Function) = ismacro(val) ? "icon-mention" : "λ"
@@ -46,5 +54,6 @@ wsicon(mod, name, ::Regex) = "icon-quote"
 wsicon(mod, name, ::Expr) = "icon-code"
 wsicon(mod, name, ::Symbol) = "icon-code"
 wsicon(mod, name, ::Exception) = "icon-bug"
+wsicon(mod, name, ::Undefined) = "icon-circle-slash"
 
 ismacro(f::Function) = startswith(string(methods(f).mt.name), "@")


### PR DESCRIPTION
handles undefined in workspace so that package developers can easily find the no more defined exports: e.g.:
![image](https://user-images.githubusercontent.com/40514306/63647005-43325e00-c756-11e9-820c-9badeea8616d.png)

And as for completions, including undefs in comoletions is what REPL completion does and so it would be more consistent.