### PR TITLE
more package completion

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -34,7 +34,9 @@ function basecompletionadapter(line, mod, force)
     # TODO: get local completions from CSTParser or similar
     # TODO: would be cool to provide `descriptionMoreURL` here to open the docpane
     if REPLCompletions.afterusing(line, first(replace))
-      c isa REPLCompletions.PackageCompletion || continue
+      (c isa REPLCompletions.PackageCompletion ||
+       (c isa REPLCompletions.ModuleCompletion && getfield′′(mod, Symbol(c.mod)) isa Module)
+      ) || continue
     end
     try
       push!(d, completion(mod, line, c))

--- a/test/completions.jl
+++ b/test/completions.jl
@@ -44,9 +44,23 @@
         comp["leftLabel"] == "String"
     end |> !isempty
 
-    @eval Main begin
-        dict = Dict(:a => 1, :b => 2)
-    end
+    @eval Main dict = Dict(:a => 1, :b => 2)
+
+    # package completion - on top level
+    line = "using B"
+    handle(line)
+    @test filter(readmsg()[3]["completions"]) do comp
+        comp["type"] ∈ ("package", "import", "module") &&
+        comp["text"] == "Base"
+    end |> !isempty
+
+    # package completion - on module level
+    line = "using C"
+    handle(line, mod = "Atom")
+    @test filter(readmsg()[3]["completions"]) do comp
+        comp["type"] ∈ ("package", "import", "module") &&
+        comp["text"] == "CodeTools"
+    end |> !isempty
 
     # property completion
     line = "dict."


### PR DESCRIPTION
Packages that aren't loaded in the `load_path` can't be completed, since 
- it's returned as `ModuleCompletios`:
https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/REPLCompletions.jl#L644-L647
- and then it's suppressed at:
https://github.com/JunoLab/Atom.jl/blob/master/src/completions.jl#L37

and this allows completions for packages that are only loaded on each module level