### PR TITLE
debugger enhancements

### DIFF
--- a/src/debugger/breakpoints.jl
+++ b/src/debugger/breakpoints.jl
@@ -120,12 +120,14 @@ handle("getBreakpoints") do
   end
 end
 
+isCompileMode() = _compiledMode[] === JuliaInterpreter.Compiled()
+
 handle("toggleCompiled") do
   with_error_message() do
-    _compiledMode[] = (_compiledMode[] === JuliaInterpreter.finish_and_return! ?
-      (_compiledMode[] = JuliaInterpreter.Compiled()) :
-      (_compiledMode[] = JuliaInterpreter.finish_and_return!))
-    return _compiledMode[] === JuliaInterpreter.Compiled()
+    _compiledMode[] = (isCompileMode() ?
+      (_compiledMode[] = JuliaInterpreter.finish_and_return!) :
+      (_compiledMode[] = JuliaInterpreter.Compiled()))
+    return isCompileMode()
   end
 end
 

--- a/src/debugger/breakpoints.jl
+++ b/src/debugger/breakpoints.jl
@@ -124,9 +124,7 @@ isCompileMode() = _compiledMode[] === JuliaInterpreter.Compiled()
 
 handle("toggleCompiled") do
   with_error_message() do
-    _compiledMode[] = (isCompileMode() ?
-      (_compiledMode[] = JuliaInterpreter.finish_and_return!) :
-      (_compiledMode[] = JuliaInterpreter.Compiled()))
+    _compiledMode[] = isCompileMode() ? JuliaInterpreter.finish_and_return! : JuliaInterpreter.Compiled()
     return isCompileMode()
   end
 end

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -72,12 +72,6 @@ function _make_frame(mod, arg)
   end
 end
 
-const prompt_color = if Sys.iswindows()
-  "\e[33m"
-else
-  "\e[38;5;166m"
-end
-
 function add_breakpoint(bp)
   cond = bp["condition"]
   cond = cond === nothing ? cond : Meta.parse(cond)
@@ -195,11 +189,15 @@ end
 
 using REPL
 using REPL.LineEdit
+using REPL.REPLCompletions
+
+const normal_prefix = Sys.iswindows() ? "\e[33m" : "\e[38;5;166m"
+const compiled_prefix = "\e[96m"
 
 function debugprompt()
   try
     panel = REPL.LineEdit.Prompt("debug> ";
-              prompt_prefix = prompt_color,
+              prompt_prefix = isCompileMode() ? compiled_prefix : normal_prefix,
               prompt_suffix = Base.text_colors[:normal],
               on_enter = s -> true)
 


### PR DESCRIPTION
- add different prompt color for compiled mode
- enable basic REPL completions in debugger REPL

we may enhance more, by enabling local completions as well (using the same logic as workspace)

***

additionally, I would like to add debugger commands that are accessible from debugger REPL like [Debugger.jl's interface](https://github.com/JuliaDebug/Debugger.jl#debugger-commands), e.g.:
- entering `:nc` in the REPL will step into the next call.

I would like to hear your ideas about these commands.