### PR TITLE
small refactors:

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -160,6 +160,7 @@ function makedescription(docs)
       return strlimit(desc, 200)
     end
   end
+  return ""
 end
 
 completionurl(c) = ""

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -8,12 +8,11 @@ using MacroTools
 
 mutable struct DebuggerState
   frame::Union{Nothing, Frame}
-  result
   broke_on_error::Bool
   level::Int
 end
-DebuggerState(frame::Frame) = DebuggerState(frame, nothing, false, 1)
-DebuggerState() = DebuggerState(nothing, nothing, false, 1)
+DebuggerState(frame::Frame) = DebuggerState(frame, false, 1)
+DebuggerState() = DebuggerState(nothing, false, 1)
 
 function active_frame(state::DebuggerState)
   frame = state.frame
@@ -97,8 +96,7 @@ function startdebugging(frame, initial_continue = false)
       if initial_continue && !JuliaInterpreter.shouldbreak(frame, frame.pc)
         ret = debug_command(_compiledMode[], frame, :c, true)
         if ret === nothing
-          STATE.result = res = JuliaInterpreter.get_return(root(frame))
-          return res
+          return res = JuliaInterpreter.get_return(root(frame))
         end
         STATE.frame = frame = ret[1]
         pc = ret[2]
@@ -157,7 +155,7 @@ function startdebugging(frame, initial_continue = false)
         end
 
         if ret === nothing
-          STATE.result = res = JuliaInterpreter.get_return(root(frame))
+          res = JuliaInterpreter.get_return(root(frame))
           break
         else
           STATE.frame = frame = ret[1]

--- a/src/frontend.jl
+++ b/src/frontend.jl
@@ -23,7 +23,7 @@ plotsize() = (@rpc plotsize()) .- 1
 ploturl(url::String) = @msg ploturl(url)
 
 
-SELECTORS = Dict(
+const SELECTORS = Dict(
   "number" => ["syntax--constant", "syntax--numeric", "syntax--julia"],
   "symbol" => ["syntax--constant", "syntax--other", "syntax--symbol", "syntax--julia"],
   "string" => ["syntax--string", "syntax--quoted", "syntax--double", "syntax--julia"],

--- a/src/path_matching.jl
+++ b/src/path_matching.jl
@@ -1,16 +1,16 @@
-uri_regex = if Sys.iswindows()
+const uri_regex = if Sys.iswindows()
   r"((?:(?:[a-zA-Z]:|\.\.?|\~)|(?:[^\0<>\?\|\/\s!$`&*()\[\]+'\":;])+)?(?:(?:\\|\/)(?:[^\0<>\?\|\/\s!$`&*()\[\]+'\":;])+)+)(?:\:(\d+))?"
 else
   r"((?:(?:\.\.?|\~)|(?:[^\0\s!$`&*()\[\]+'\":;\\])+)?(?:\/(?:[^\0\s!$`&*()\[\]+'\":;\\])+)+)(?:\:(\d+))?"
 end
 
-buildbot_regex = if Sys.iswindows()
+const buildbot_regex = if Sys.iswindows()
   r"C:\\cygwin\home\\Admininstrator\\buildbot\\.*?(\\julia\\stdlib\\.*?\.jl)"
 else
   r"\/buildworker\/worker\/.*?(\/julia\/stdlib\/.*?\.jl)"
 end
 
-repl_at_regex = r"@ (?:[^\s]+)\s(.*?)\:(\d+)"
+const repl_at_regex = r"@ (?:[^\s]+)\s(.*?)\:(\d+)"
 
 function fullREPLpath(uri)
   urimatch = match(repl_at_regex, uri)


### PR DESCRIPTION
- remove unnecessary field from DebuggerState
- type structs in outline.jl
- more const
- remove union type from `makedescription`

neither of them is slow from for now, thus the changes above wouldn't be any important tho.