### PR TITLE
improve completions/outline

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -12,8 +12,8 @@ handle("completions") do data
 
     cs, pre = basecompletionadapter(line, m, force, lineNumber - startLine, column, editorContent)
 
-    d(:completions => cs,
-      :prefix      => string(pre))
+    Dict(:completions => cs,
+         :prefix      => string(pre))
   end
 end
 
@@ -27,9 +27,10 @@ function basecompletionadapter(line, mod, force, lineNumber, column, text)
     [], 1:0, false
   end
 
-  # suppress completions if there are too many of them unless activated manually
-  # checking if `line` is a valid text to be completed in atom-julia-client beforehand would be better
-  (!force && length(comps) > MAX_COMPLETIONS) && begin
+  # Suppress completions if there are too many of them unless activated manually
+  # @TODO: Checking whether `line` is a valid text to be completed in atom-julia-client
+  #        in advance and drop this check
+  if !force && length(comps) > MAX_COMPLETIONS
     comps = []
     replace = 1:0
   end

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -83,19 +83,19 @@ function toplevel_bindings(expr, text, bindings = [], line = 1, pos = 1)
     return bindings
 end
 
-struct LocalScope
-    name
-    span
-    line
-    children
-    expr
+struct LocalBinding
+    name::String
+    span::UnitRange{Int64}
+    line::Int
+    expr::CSTParser.EXPR
 end
 
-struct LocalBinding
-    name
-    span
-    line
-    expr
+struct LocalScope
+    name::String
+    span::UnitRange{Int64}
+    line::Int
+    children::Vector{Union{LocalBinding, LocalScope}}
+    expr::CSTParser.EXPR
 end
 
 function scopeof(expr)

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -4,7 +4,6 @@ handle("outline") do text
     try
         outline(text)
     catch err
-        @error err
         []
     end
 end
@@ -75,9 +74,6 @@ function toplevel_bindings(expr, text, bindings = [], line = 1, pos = 1)
         return bindings
     end
     if expr.args !== nothing
-        if expr.typ == CSTParser.Kw
-            return bindings
-        end
         for arg in expr.args
             toplevel_bindings(arg, text, bindings, line, pos)
             line += count(c -> c === '\n', text[nextind(text, pos - 1):prevind(text, pos + arg.fullspan)])
@@ -107,6 +103,7 @@ function scopeof(expr)
     if scope ≠ nothing
         return scope
     else
+        # can remove this with CSTParser 0.6.3
         if expr.typ == CSTParser.BinaryOpCall && expr.args[2].kind == CSTParser.Tokens.ANON_FUNC
             return :anon
         end
@@ -222,8 +219,6 @@ function str_value(x)
         return string("\"\"\"", x.val, "\"\"\"")
     elseif x.kind === CSTParser.Tokens.STRING
         return string("\"", x.val, "\"")
-    elseif x.kind === CSTParser.Tokens.CHAR
-        return string("\'", x.val, "\'")
     elseif x.typ === CSTParser.IDENTIFIER || x.typ === CSTParser.LITERAL || x.typ === CSTParser.OPERATOR || x.typ === CSTParser.KEYWORD
         return CSTParser.str_value(x)
     else

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -1,7 +1,12 @@
 using CSTParser
 
 handle("outline") do text
-    return outline(text)
+    try
+        outline(text)
+    catch err
+        @error err
+        []
+    end
 end
 
 function outline(text)
@@ -49,12 +54,14 @@ end
 
 function toplevel_bindings(expr, text, bindings = [], line = 1, pos = 1)
     bind = CSTParser.bindingof(expr)
+
     if bind !== nothing
         name = bind.name
-        if CSTParser.has_sig(bind.val)
-            sig = CSTParser.get_sig(bind.val)
+        if CSTParser.has_sig(expr)
+            sig = CSTParser.get_sig(expr)
             name = str_value(sig)
         end
+
         push!(bindings, Dict(
                 :name => name,
                 :type => static_type(bind),
@@ -63,11 +70,14 @@ function toplevel_bindings(expr, text, bindings = [], line = 1, pos = 1)
                 )
              )
     end
-    scope = CSTParser.scopeof(expr)
+    scope = scopeof(expr)
     if scope !== nothing && !(expr.typ === CSTParser.FileH || expr.typ === CSTParser.ModuleH || expr.typ === CSTParser.BareModule)
         return bindings
     end
     if expr.args !== nothing
+        if expr.typ == CSTParser.Kw
+            return bindings
+        end
         for arg in expr.args
             toplevel_bindings(arg, text, bindings, line, pos)
             line += count(c -> c === '\n', text[nextind(text, pos - 1):prevind(text, pos + arg.fullspan)])
@@ -77,41 +87,63 @@ function toplevel_bindings(expr, text, bindings = [], line = 1, pos = 1)
     return bindings
 end
 
-struct LocalBinding
-    name::String
-    span::UnitRange{Int}
-    expr::CSTParser.EXPR
-end
-
 struct LocalScope
-    name::String
-    span::UnitRange{Int}
-    children::Vector{Union{LocalBinding, LocalScope}}
-    expr::CSTParser.EXPR
+    name
+    span
+    line
+    children
+    expr
 end
 
-function local_bindings(expr, bindings = Vector{Union{LocalBinding, LocalScope}}([]), pos = 1)
-    bind = CSTParser.bindingof(expr)
+struct LocalBinding
+    name
+    span
+    line
+    expr
+end
+
+function scopeof(expr)
     scope = CSTParser.scopeof(expr)
+    if scope ≠ nothing
+        return scope
+    else
+        if expr.typ == CSTParser.BinaryOpCall && expr.args[2].kind == CSTParser.Tokens.ANON_FUNC
+            return :anon
+        end
+
+        if expr.typ == CSTParser.Call && expr.parent ≠ nothing && scopeof(expr.parent) == nothing
+            return :call
+        end
+    end
+    return nothing
+end
+
+function local_bindings(expr, text, bindings = [], pos = 1, line = 1)
+    bind = CSTParser.bindingof(expr)
+    scope = scopeof(expr)
     if bind !== nothing && scope === nothing
-        push!(bindings, LocalBinding(bind.name, pos:pos+expr.span, expr))
+        push!(bindings, LocalBinding(bind.name, pos:pos+expr.span, line, expr))
     end
 
     if scope !== nothing
         range = pos:pos+expr.span
-        localbindings = Vector{Union{LocalBinding, LocalScope}}([])
+        localbindings = []
+        if expr.typ == CSTParser.Kw
+            return bindings
+        end
         if expr.args !== nothing
             for arg in expr.args
-                local_bindings(arg, localbindings, pos)
-
+                local_bindings(arg, text, localbindings, pos, line)
+                line += count(c -> c === '\n', text[nextind(text, pos - 1):prevind(text, pos + arg.fullspan)])
                 pos += arg.fullspan
             end
         end
-        push!(bindings, LocalScope(bind === nothing ? "" : bind.name, range, localbindings, expr))
+        push!(bindings, LocalScope(bind === nothing ? "" : bind.name, range, line, localbindings, expr))
         return bindings
     elseif expr.args !== nothing
         for arg in expr.args
-            local_bindings(arg, bindings, pos)
+            local_bindings(arg, text, bindings, pos, line)
+            line += count(c -> c === '\n', text[nextind(text, pos - 1):prevind(text, pos + arg.fullspan)])
             pos += arg.fullspan
         end
     end
@@ -133,9 +165,8 @@ function locals(text, line, col)
         c === '\n' && (current_line += 1)
     end
     parsed = CSTParser.parse(text, true)
-
-    bindings = local_bindings(parsed)
-    bindings = filter_local_bindings(bindings, byteoffset)
+    bindings = local_bindings(parsed, text)
+    bindings = filter_local_bindings(bindings, line, byteoffset)
     bindings = filter(x -> !isempty(x[:name]), bindings)
     bindings = sort(bindings, lt = (a,b) -> a[:locality] < b[:locality])
     bindings = unique(x -> x[:name], bindings)
@@ -143,23 +174,37 @@ function locals(text, line, col)
     bindings
 end
 
-function filter_local_bindings(bindings, byteoffset, root = "", actual_bindings = [])
+function distance(line, byteoffset, defline, defspan)
+    abslinediff = abs(line - defline)
+    absbytediff = abs(byteoffset - defspan[1]) # tiebreaker for bindings on the same line
+    diff = if byteoffset in defspan
+        Inf
+    elseif line < defline
+        (defline - line)*10 # bindings defined *after* the current line have a lower priority
+    else
+        line - defline
+    end
+    diff + absbytediff*1e-6
+end
+
+function filter_local_bindings(bindings, line, byteoffset, root = "", actual_bindings = [])
     for bind in bindings
         push!(actual_bindings, Dict(
             :name => bind.name,
             :root => root,
-            :locality => abs(bind.span[1] - byteoffset),
+            :locality => distance(line, byteoffset, bind.line, bind.span),
             :icon => static_icon(bind.expr),
             :type => static_type(bind.expr)
         ))
         if bind isa LocalScope && byteoffset in bind.span
-            filter_local_bindings(bind.children, byteoffset, bind.name, actual_bindings)
+            filter_local_bindings(bind.children, line, byteoffset, bind.name, actual_bindings)
         end
     end
+
     actual_bindings
 end
 
-# https://github.com/julia-vscode/DocumentFormat.jl/blob/b7e22ca47254007b5e7dd3c678ba27d8744d1b1f/src/passes.jl#L108
+# adapted from https://github.com/julia-vscode/DocumentFormat.jl/blob/b7e22ca47254007b5e7dd3c678ba27d8744d1b1f/src/passes.jl#L108
 function str_value(x)
     if x.typ === CSTParser.PUNCTUATION
         x.kind == CSTParser.Tokens.LPAREN && return "("
@@ -173,6 +218,12 @@ function str_value(x)
         x.kind == CSTParser.Tokens.AT_SIGN && return "@"
         x.kind == CSTParser.Tokens.DOT && return "."
         return ""
+    elseif x.kind === CSTParser.Tokens.TRIPLE_STRING
+        return string("\"\"\"", x.val, "\"\"\"")
+    elseif x.kind === CSTParser.Tokens.STRING
+        return string("\"", x.val, "\"")
+    elseif x.kind === CSTParser.Tokens.CHAR
+        return string("\'", x.val, "\'")
     elseif x.typ === CSTParser.IDENTIFIER || x.typ === CSTParser.LITERAL || x.typ === CSTParser.OPERATOR || x.typ === CSTParser.KEYWORD
         return CSTParser.str_value(x)
     else

--- a/test/completions.jl
+++ b/test/completions.jl
@@ -169,13 +169,14 @@ end
 
     let str = """
        const bar = 2
-       function f(x)
+       function f(x=2) # `x` should show up in completions
          ff = function (x, xxx)
            z = 3
          end
          y = x
          return y+x
        end
+       kwfun(kw = 3) # `kw` should not show up in completions
        function foo(x)
          asd = 3
        end
@@ -197,12 +198,13 @@ end
             a
 
             foo = x
-
             a
             abc = 3
+            a
         end
         """
         @test Atom.basecompletionadapter("a", Main, true, 3, 6, str)[1][1][:text] == "aaa"
-        @test Atom.basecompletionadapter("a", Main, true, 6, 6, str)[1][1][:text] == "abc"
+        @test Atom.basecompletionadapter("a", Main, true, 6, 6, str)[1][1][:text] == "aaa"
+        @test Atom.basecompletionadapter("a", Main, true, 8, 6, str)[1][1][:text] == "abc"
     end
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -69,4 +69,26 @@ end
             )
         ]
     end
+    # kwargs shouldn't show up in outline, same as anon function args
+    let str = """
+        function bar(foo = 3)
+            2x
+        end
+        const foo = (a,b) -> a+b
+        """
+        @test Atom.outline(str) == Any[
+            Dict(
+                :type => "function",
+                :name => "bar(foo=3)",
+                :icon => "λ",
+                :lines => [1, 3]
+            ),
+            Dict(
+                :type => "variable",
+                :name => "foo",
+                :icon => "v",
+                :lines => [4, 4]
+            ),
+        ]
+    end
 end


### PR DESCRIPTION
- don't include function arguments in outline
- stop kwargs/anon function args form leaking into outer scope
- improve locality based completion ranking by basing it on lines 
instead of the byteoffset
- give bindings defined *before* the current line a higher priority