### PR TITLE
no named tuple elements in outline

### DIFF
--- a/src/outline.jl
+++ b/src/outline.jl
@@ -111,6 +111,10 @@ function scopeof(expr)
         if expr.typ == CSTParser.Call && expr.parent ≠ nothing && scopeof(expr.parent) == nothing
             return :call
         end
+
+        if expr.typ == CSTParser.TupleH && expr.parent ≠ nothing && scopeof(expr.parent) == nothing
+            return :tupleh
+        end
     end
     return nothing
 end

--- a/test/completions.jl
+++ b/test/completions.jl
@@ -173,7 +173,7 @@ end
          ff = function (x, xxx)
            z = 3
          end
-         y = x
+         y = (foo = 3, bar = 4) # named tuple elements shouldn't show up in completions
          return y+x
        end
        kwfun(kw = 3) # `kw` should not show up in completions

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -75,6 +75,7 @@ end
             2x
         end
         const foo = (a,b) -> a+b
+        const bar = (asd=3, bsd=4)
         """
         @test Atom.outline(str) == Any[
             Dict(
@@ -88,6 +89,12 @@ end
                 :name => "foo",
                 :icon => "v",
                 :lines => [4, 4]
+            ),
+            Dict(
+                :type => "variable",
+                :name => "bar",
+                :icon => "v",
+                :lines => [5, 5]
             ),
         ]
     end


### PR DESCRIPTION
and completions.
Fixes https://github.com/JunoLab/Atom.jl/issues/171.