### PR TITLE
refactors around `get` methods

### DIFF
--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -38,6 +38,7 @@ function __init__()
 end
 
 include("comm.jl")
+include("utils.jl")
 include("display/display.jl")
 include("progress.jl")
 include("eval.jl")
@@ -50,7 +51,6 @@ include("completions.jl")
 include("misc.jl")
 include("formatter.jl")
 include("frontend.jl")
-include("utils.jl")
 
 include("debugger/debugger.jl")
 

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -124,7 +124,7 @@ completionsummary(mod, c::REPLCompletions.ModuleCompletion) = begin
   word = c.mod
 
   !cangetdocs(mod, Symbol(word)) && return ""
-  getdocs(string(mod), word) |> makedescription
+  getdocs(mod, word) |> makedescription
 end
 completionsummary(mod, c::REPLCompletions.MethodCompletion) = begin
   ct = Symbol(c.func)
@@ -133,7 +133,7 @@ completionsummary(mod, c::REPLCompletions.MethodCompletion) = begin
   description(b, Base.tuple_type_tail(c.method.sig))
 end
 completionsummary(mod, c::REPLCompletions.KeywordCompletion) = begin
-  getdocs(string(mod), c.keyword) |> makedescription
+  getdocs(mod, c.keyword) |> makedescription
 end
 
 function cangetdocs(m, s)
@@ -169,7 +169,7 @@ completionurl(c::REPLCompletions.PackageCompletion) =
   "atom://julia-client/?moduleinfo=true&mod=$(c.package)"
 completionurl(c::REPLCompletions.ModuleCompletion) = begin
   mod, name = c.parent, c.mod
-  val = getfield′′(mod, Symbol(name))
+  val = getfield′(mod, name)
   if val isa Module # module info
     parentmodule(val) == val || val ∈ (Main, Base, Core) ?
       "atom://julia-client/?moduleinfo=true&mod=$(name)" :
@@ -227,7 +227,7 @@ completionicon(c::REPLCompletions.ModuleCompletion) = begin
   ismacro(c.mod) && return "icon-mention"
   mod = c.parent
   name = Symbol(c.mod)
-  val = getfield′′(mod, name)
+  val = getfield′(mod, name)
   wsicon(mod, name, val)
 end
 completionicon(::REPLCompletions.PathCompletion) = "icon-file"

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -8,7 +8,7 @@ handle("completions") do data
              line, force] = data
 
   withpath(path) do
-    m = getmodule′(mod)
+    m = getmodule(mod)
 
     cs, pre = basecompletionadapter(line, m, force, lineNumber - startLine, column, editorContent)
 

--- a/src/display/base.jl
+++ b/src/display/base.jl
@@ -28,8 +28,6 @@ render(::Console, x::Expr) =
     span(ls[1])
 end
 
-getfield′(x, f) = isdefined(x, f) ? getfield(x, f) : UNDEF
-
 showmethod(args...) = which(show, (IO, args...))
 
 const inline_mime = "application/prs.juno.inline"
@@ -68,8 +66,8 @@ function defaultrepr(x, lazy = false)
   if isempty(fields)
     span(c(render(Inline(), typeof(x)), "()"))
   else
-    lazy ? LazyTree(typeof(x), () -> [SubTree(Text("$f → "), getfield′(x, f)) for f in fields]) :
-           Tree(typeof(x), [SubTree(Text("$f → "), getfield′(x, f)) for f in fields])
+    lazy ? LazyTree(typeof(x), () -> [SubTree(Text("$f → "), getfield′(x, f, UNDEF)) for f in fields]) :
+           Tree(typeof(x), [SubTree(Text("$f → "), getfield′(x, f, UNDEF)) for f in fields])
   end
 end
 
@@ -95,6 +93,8 @@ end
 @render Inline x::VersionNumber span(".syntax--string.syntax--quoted.syntax--other", sprint(show, x))
 
 @render Inline _::Nothing span(".syntax--constant", "nothing")
+
+@render Inline _::Undefined span(".fade", "<undefined>")
 
 import Base.Docs: doc
 

--- a/src/display/frontend.jl
+++ b/src/display/frontend.jl
@@ -5,7 +5,7 @@ function structure(x)
       Row(typeof(x), Text(" "), x) :
       Row(typeof(x), Text("()"))
   else
-    LazyTree(typeof(x), () -> [SubTree(Text("$f → "), structure(getfield′(x, f))) for f in fields])
+    LazyTree(typeof(x), () -> [SubTree(Text("$f → "), structure(getfield′(x, f, UNDEF))) for f in fields])
   end
 end
 

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -35,7 +35,7 @@ function renderitem(x)
   r[:typ], r[:icon], r[:nativetype] = if (name !== :ans || mod === Base) && name ∈ keys(Docs.keywords)
     "keyword", "k", x.typ
   else
-    val = getfield′′(mod, name)
+    val = getfield′(mod, name)
     # @NOTE: DocSeeker can show docs for non-loaded packages via `createdocsdb()`
     nativetype = val isa Undefined ? "Undefined or not loaded yet" : x.typ
     wstype(mod, name, val), wsicon(mod, name, val), nativetype

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -30,7 +30,7 @@ function renderitem(x)
   r = Dict(f => getfield(x, f) for f in fieldnames(DocSeeker.DocObj))
   r[:html] = view(renderMD(x.html))
 
-  mod = getmodule′(x.mod)
+  mod = getmodule(x.mod)
   name = Symbol(x.name)
   r[:typ], r[:icon], r[:nativetype] = if (name !== :ans || mod === Base) && name ∈ keys(Docs.keywords)
     "keyword", "k", x.typ

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -1,5 +1,4 @@
 using CodeTools, LNR, Media
-using CodeTools: getthing, getmodule
 import REPL
 
 using Logging: with_logger
@@ -18,11 +17,6 @@ function modulenames(data, pos)
   main == "" && (main = "Main")
   sub = CodeTools.codemodule(data["code"], pos)
   main, sub
-end
-
-function getmodule′(args...)
-  m = getmodule(args...)
-  return m == nothing ? Main : m
 end
 
 handle("module") do data
@@ -195,19 +189,6 @@ handle("docs") do data
        :type     => :dom,
        :tag      => :div,
        :contents =>  map(x -> render(Inline(), x), [docstring; mtable]))
-end
-
-function getmethods(mod, word)
-  methods(CodeTools.getthing(getmodule′(mod), word))
-end
-
-function getdocs(mod, word)
-  md = if Symbol(word) in keys(Docs.keywords)
-    Core.eval(Main, :(@doc($(Symbol(word)))))
-  else
-    include_string(getmodule′(mod), "@doc $word")
-  end
-  return md_hlines(md)
 end
 
 handle("methods") do data

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -22,8 +22,8 @@ end
 handle("module") do data
   main, sub = modulenames(data, cursor(data))
 
-  mod = getmodule(main)
-  smod = getmodule(mod, sub)
+  mod = CodeTools.getmodule(main)
+  smod = CodeTools.getmodule(mod, sub)
 
   return d(:main => main,
            :sub  => sub,
@@ -46,7 +46,7 @@ handle("evalshow") do data
   fixjunodisplays()
   @dynamic let Media.input = Editor()
     @destruct [text, line, path, mod] = data
-    mod = getmodule′(mod)
+    mod = getmodule(mod)
 
     lock(evallock)
     result = hideprompt() do
@@ -79,7 +79,7 @@ handle("eval") do data
   fixjunodisplays()
   @dynamic let Media.input = Editor()
     @destruct [text, line, path, mod, displaymode || "editor"] = data
-    mod = getmodule′(mod)
+    mod = getmodule(mod)
 
     lock(evallock)
     result = hideprompt() do
@@ -103,9 +103,9 @@ handle("evalall") do data
   @dynamic let Media.input = Editor()
     @destruct [setmod = :module || nothing, path || "untitled", code] = data
     mod = if setmod ≠ nothing
-       getmodule′(setmod)
+       getmodule(setmod)
     elseif isabspath(path)
-      getmodule′(CodeTools.filemodule(path))
+      getmodule(CodeTools.filemodule(path))
     else
       Main
     end
@@ -154,7 +154,7 @@ handle("evalrepl") do data
       render′(@errs getdocs(mod, code))
       return
     end
-    mod = getmodule′(mod)
+    mod = getmodule(mod)
     if isdebugging()
       render(Console(), @errs Debugger.interpret(code))
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -120,7 +120,7 @@ or `default` if no such a field is found.
 """
 getfield′(mod::Module, name::String, default = Undefined()) = CodeTools.getthing(mod, name, default)
 getfield′(mod::Module, name::Symbol, default = Undefined()) = getfield′(mod, string(name), default)
-getfield′(@nospecialize(object), name::Symbol, default = Undefined()) = isdefined(mod, name) ? getfield(mod, name) : Undefined()
+getfield′(@nospecialize(object), name::Symbol, default = Undefined()) = isdefined(object, name) ? getfield(object, name) : default
 
 """
     getmodule(mod::String)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -103,3 +103,55 @@ function strlimit(str::AbstractString, limit = 30)
   str = lastindex(str) > limit ?  str[1:prevind(str, limit)]*"…" : str
   filter(isvalid, str)
 end
+
+# singleton type for undefined values
+struct Undefined end
+
+# get utilities
+using CodeTools: getthing, getmodule
+
+@doc """
+    getfield′(mod::Module, name::Symbol, default = Undefined())
+    getfield′(mod::Module, name::String, default = Undefined())
+    getfield′(object, name::Symbol, default = Undefined())
+
+Returns the specified field of a given `Module` or some arbitrary `object`,
+or `default` if no such a field is found.
+"""
+function getfield′(mod::Module, name::Symbol, default = Undefined())
+  return getthing(mod, string(name), default)
+end
+function getfield′(mod::Module, name::String, default = Undefined())
+  return getthing(mod, name, default)
+end
+function getfield′(@nospecialize(object), name::Symbol, default = Undefined())
+  return isdefined(mod, name) ? getfield(mod, name) : Undefined()
+end
+
+@doc """
+    getmodule′(mod::String)
+    getmodule′(parent::Union{Nothing, Module}, mod::String)
+    getmodule′(code::AbstractString, pos; filemod)
+
+Calls [`CodeTools.getmodule`](@ref), but returns `Main` instead of `nothing` in a fallback case.
+"""
+function getmodule′(args...)
+  m = getmodule(args...)
+  return m == nothing ? Main : m
+end
+
+function getmethods(mod::String, word::String)
+  return methods(getthing(getmodule′(mod), word))
+end
+
+function getdocs(mod::String, word::String)
+  md = if Symbol(word) in keys(Docs.keywords)
+    Core.eval(Main, :(@doc($(Symbol(word)))))
+  else
+    include_string(getmodule′(mod), "@doc $word")
+  end
+  return md_hlines(md)
+end
+function getdocs(mod::Module, word::String)
+  getdocs(string(mod), word)
+end

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -1,5 +1,5 @@
 handle("workspace") do mod
-  mod = getmodule′(mod)
+  mod = getmodule(mod)
   ns = Symbol.(CodeTools.filtervalid(names(mod; all = true)))
   filter!(ns) do n
     !Base.isdeprecated(mod, n) &&

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -11,7 +11,7 @@ handle("workspace") do mod
 end
 
 wsitem(mod, name) = begin
-  val = getfield′′(mod, name)
+  val = getfield′(mod, name)
   wsitem(mod, name, val)
 end
 wsitem(mod, name, @nospecialize(val)) = begin
@@ -22,10 +22,6 @@ wsitem(mod, name, @nospecialize(val)) = begin
     :icon       => wsicon(mod, name, val))
 end
 
-# handle undefineds
-struct Undefined end
-getfield′′(mod, name) = isdefined(mod, name) ? getfield(mod, name) : Undefined()
-@render Inline val::Undefined span(".fade", "<undefined>")
 nativetype(mod, name, @nospecialize(val)) = DocSeeker.determinetype(mod, name)
 nativetype(mod, name, ::Undefined) = "Undefined"
 


### PR DESCRIPTION
refactor get moethods: …
- define getter methods in one place: utils.jl
- add type annotation and docs for better development
- `getfield′` now uses `CodeTools.getthing`
     * e.g.: #173 will be able to handle `Atom.handlers` in `Atom` module

getmodule′ -> getmodule: