### PR TITLE
aggregate methods with default args within goto

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -166,7 +166,9 @@ handle("methods") do data
   if mtable isa EvalError
     Dict(:error => true, :items => sprint(showerror, mtable.err))
   else
-    Dict(:error => false, :items => [gotoitem(m) for m in mtable])
+    # only show the method with full default arguments
+    aggregated = @>> mtable collect sort(by = m -> m.nargs, rev = true) unique(m -> (m.file, m.line))
+    Dict(:error => false, :items => [gotoitem(m) for m in aggregated])
   end
 end
 

--- a/test/eval.jl
+++ b/test/eval.jl
@@ -7,22 +7,36 @@
                        Dict("word"     => word,
                             "mod"      => mod))
 
-    # toggle docs
+    ## toggle docs
+
     # basic
     handle("docs", "push!")
     @test !readmsg()[3]["error"]
+
     # context module
     handle("docs", "handlemsg", "Atom")
     @test !readmsg()[3]["error"]
+
     # keyword
     handle("docs", "begin", "Atom")
     @test !readmsg()[3]["error"]
 
-    # goto symbols
-    # basic
-    handle("methods", "push!")
-    @test length(readmsg()[3]["items"]) == length(methods(push!))
-    # context module
+    ## goto symbols
+
+    # basic - `Atom.handlemsg` is not defined with default args
+    handle("methods", "Atom.handlemsg")
+    @test length(readmsg()[3]["items"]) === length(methods(Atom.handlemsg))
+
+    # module awareness
     handle("methods", "handlemsg", "Atom")
-    @test length(readmsg()[3]["items"]) == length(methods(Atom.handlemsg)) # == 1
+    @test length(readmsg()[3]["items"]) === length(methods(Atom.handlemsg))
+
+    # aggregate methods with default params
+    @eval Main function funcwithdefaultargs(args, defarg = "default") end
+    handle("methods", "funcwithdefaultargs") # should be handled as an unique method
+    @test length(readmsg()[3]["items"]) === 1
+
+    @eval Main function funcwithdefaultargs(args::Vector, defarg = "default") end
+    handle("methods", "funcwithdefaultargs") # should be handled as a different method
+    @test length(readmsg()[3]["items"]) === 2
 end


### PR DESCRIPTION
A method definition with default arguments introduces different method instances, but they are better to be handled as an unique method in terms of "goto method", since their definition location is exactly same, and otherwise they might appear verbose.

- the methods with full arguments are going to be shown as a representative of the other _incomplete_ methods
- Tests are added.