### PR TITLE
make plots devicePixelRatio aware

### DIFF
--- a/src/display/showdisplay.jl
+++ b/src/display/showdisplay.jl
@@ -2,7 +2,19 @@ using REPL, Base64
 
 struct JunoDisplay <: AbstractDisplay end
 
-plotpane_io_ctx(io::IO) = IOContext(io, :juno_plotsize => plotsize(), :juno_colors => syntaxcolors())
+function plotpane_io_ctx(io::IO)
+  info = @rpc plotsize()
+  if info isa Array
+    size = info
+    dpi = 1
+  else
+    size = info["size"]
+    dpi = info["ratio"]
+  end
+  size .-= 1
+
+  IOContext(io, :juno_plotsize => size, :juno_dpi_ratio => dpi, :juno_colors => syntaxcolors())
+end
 
 const plain_mimes = [
   "image/png",

--- a/src/frontend.jl
+++ b/src/frontend.jl
@@ -18,7 +18,17 @@ end
 
 clearconsole() = @rpc clearconsole()
 
-plotsize() = (@rpc plotsize()) .- 1
+function plotsize()
+  info = @rpc plotsize()
+  size = if info isa Array
+    info
+  elseif haskey(info, "size")
+    info["size"]
+  else
+    [401, 501]
+  end
+  size .- 1
+end
 
 ploturl(url::String) = @msg ploturl(url)
 


### PR DESCRIPTION
Needs https://github.com/JunoLab/atom-julia-client/pull/609 to do something useful, but will work regardless.