### PR TITLE
enhance completions within the integrated REPL

### DIFF
--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -11,7 +11,9 @@ import Media: @dynamic
 function __init__()
   Juno.activate()
 
-  atreplinit(i -> fixdisplayorder())
+  atreplinit() do repl
+    fixdisplayorder()
+  end
 
   Atom.handle("connected") do
     if isREPL()

--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -16,7 +16,7 @@ function __init__()
   end
 
   Atom.handle("connected") do
-    if isREPL()
+    if isREPL(before_run_repl = true)
       reset_repl_history()
       fixdisplayorder()
 

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -207,17 +207,15 @@ function reset_repl_history()
   replc = mode.complete
 
   if Base.active_repl.history_file
-      try
-          hist_path = REPL.find_hist_file()
-          mkpath(dirname(hist_path))
-          f = open(hist_path, read=true, write=true, create=true)
-          finalizer(replc) do replc
-              close(f)
-          end
-          REPL.hist_from_file(hp, f, hist_path)
-          REPL.history_reset_state(hp)
-      catch e
-      end
+    try
+      hist_path = REPL.find_hist_file()
+      mkpath(dirname(hist_path))
+      f = open(hist_path, read=true, write=true, create=true)
+      atexit(() -> close(f))
+      REPL.hist_from_file(hp, f, hist_path)
+      REPL.history_reset_state(hp)
+    catch e
+    end
   end
 end
 


### PR DESCRIPTION
First I tried to enable this feature via https://github.com/JuliaLang/julia/pull/33102, but the PR would take more time to be finished I think, and so I want to _partly_ realise that here:

Pros:
- we can get module-aware completions within the integrated REPL

Cons:
- an user can no longer has their own custom `complete` within Juno: it's automatically updated by each call of `changemodule`
- help mode is still not module-aware (that's why this feature is still "partly" realised)

Alternative design:
- if we use an weird global `context_module` for REPL completions, then we can attach our custom completion provider on `atreplinit`, and then it would allow an user's custom `complete`
