### PR TITLE
debugger refactors

### DIFF
--- a/src/debugger/datatip.jl
+++ b/src/debugger/datatip.jl
@@ -3,11 +3,14 @@ using JuliaInterpreter: getfile, locals
 import ..Atom: fullpath, strlimit
 
 function datatip(word, path, row, column, state::DebuggerState = STATE)
-  frame = state.frame
+  # frame validation
+  state.frame === nothing && return nothing
+
+  frame = active_frame(state)
   scope = frame.framecode.scope
 
-  # frame validation & only work for methods
-  (frame === nothing || scope isa Module) && return nothing
+  # only work for methods
+  scope isa Module && return nothing
 
   # path identity check
   path != fullpath(getfile(frame)) && return nothing

--- a/src/debugger/datatip.jl
+++ b/src/debugger/datatip.jl
@@ -1,6 +1,6 @@
 using CodeTracking
 using JuliaInterpreter: getfile, locals
-import ..Atom: strlimit
+import ..Atom: fullpath, strlimit
 
 function datatip(word, path, row, column, state::DebuggerState = STATE)
   frame = state.frame
@@ -10,7 +10,7 @@ function datatip(word, path, row, column, state::DebuggerState = STATE)
   (frame === nothing || scope isa Module) && return nothing
 
   # path identity check
-  path != getfile(frame) && return nothing
+  path != fullpath(getfile(frame)) && return nothing
 
   # line number check
   defstr, startline = definition(String, scope)

--- a/src/debugger/datatip.jl
+++ b/src/debugger/datatip.jl
@@ -2,14 +2,12 @@ using CodeTracking
 using JuliaInterpreter: getfile, locals
 import ..Atom: strlimit
 
-function datatip(word, path, row, column, s::DebuggerState = STATE)
-  frame = s.frame
+function datatip(word, path, row, column, state::DebuggerState = STATE)
+  frame = state.frame
+  scope = frame.framecode.scope
 
   # frame validation & only work for methods
-  scope = frame.framecode.scope
-  if frame === nothing || scope isa Module
-    return nothing
-  end
+  (frame === nothing || scope isa Module) && return nothing
 
   # path identity check
   path != getfile(frame) && return nothing
@@ -20,10 +18,10 @@ function datatip(word, path, row, column, s::DebuggerState = STATE)
   startline <= row <= endline || return nothing
 
   # local bindings
-  for v in s.locals
-    if string(v.name) === word
+  for v in locals(frame)
+    if string(v.name) == word
       valstr = @> repr(MIME("text/plain"), v.value, context = :limit => true) strlimit(1000)
-      return [Dict(:type  => :snippet, :value => valstr)]
+      return [Dict(:type => :snippet, :value => valstr)]
     end
   end
 

--- a/src/debugger/datatip.jl
+++ b/src/debugger/datatip.jl
@@ -1,0 +1,31 @@
+using CodeTracking
+using JuliaInterpreter: getfile, locals
+import ..Atom: strlimit
+
+function datatip(word, path, row, column, s::DebuggerState = STATE)
+  frame = s.frame
+
+  # frame validation & only work for methods
+  scope = frame.framecode.scope
+  if frame === nothing || scope isa Module
+    return nothing
+  end
+
+  # path identity check
+  path != getfile(frame) && return nothing
+
+  # line number check
+  defstr, startline = definition(String, scope)
+  endline = startline + sum(c === '\n' for c in defstr)
+  startline <= row <= endline || return nothing
+
+  # local bindings
+  for v in locals(frame)
+    if string(v.name) === word
+      valstr = @> repr(MIME("text/plain"), v.value, context = :limit => true) strlimit(1000)
+      return [Dict(:type  => :snippet, :value => valstr)]
+    end
+  end
+
+  return nothing # when no local binding exists
+end

--- a/src/debugger/datatip.jl
+++ b/src/debugger/datatip.jl
@@ -20,7 +20,7 @@ function datatip(word, path, row, column, s::DebuggerState = STATE)
   startline <= row <= endline || return nothing
 
   # local bindings
-  for v in locals(frame)
+  for v in s.locals
     if string(v.name) === word
       valstr = @> repr(MIME("text/plain"), v.value, context = :limit => true) strlimit(1000)
       return [Dict(:type  => :snippet, :value => valstr)]

--- a/src/debugger/debugger.jl
+++ b/src/debugger/debugger.jl
@@ -12,10 +12,15 @@ end
 
 isdebugging() = JunoDebugger.isdebugging()
 
+
 module JunoDebugger
+
 using ..Atom, MacroTools, Lazy, Hiccup
 
 include("breakpoints.jl")
+include("repl.jl")
 include("stepper.jl")
+include("workspace.jl")
+include("datatip.jl")
 
 end # module

--- a/src/debugger/debugger.jl
+++ b/src/debugger/debugger.jl
@@ -36,9 +36,7 @@ function __init__()
 
       # enables `MethodCompletion`, `PropertyCompletion`, `FieldCompletion` including local bindings
       if isdebugging()
-        global STATE
-        vars = locals(STATE.frame)
-        for var in vars
+        for var in STATE.locals
           sym === var.name && return var.value, true
         end
       end
@@ -54,7 +52,7 @@ function __init__()
 
       # inject local names for `ModuleCompletion`s
       if isdebugging()
-        @>> locals(STATE.frame) map(v -> string(v.name)) append!(syms)
+        @>> map(v -> string(v.name), STATE.locals) append!(syms)
       end
 
       macros =  filter(x -> startswith(x, "@" * name), syms)

--- a/src/debugger/debugger.jl
+++ b/src/debugger/debugger.jl
@@ -31,20 +31,19 @@ function __init__()
     using JuliaInterpreter: locals
 
     # adapted from https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/REPLCompletions.jl#L348
+    # enables `MethodCompletion`, `PropertyCompletion`, `FieldCompletion` including local bindings
     function get_value(sym::Symbol, fn)
-      isdefined(fn, sym) && return getfield(fn, sym), true
-
-      # enables `MethodCompletion`, `PropertyCompletion`, `FieldCompletion` including local bindings
+      # first look up local bindings
       if isdebugging()
         for var in STATE.locals
           sym === var.name && return var.value, true
         end
       end
-
-      return (nothing, false)
+      return isdefined(fn, sym) ? (getfield(fn, sym), true) : (nothing, false)
     end
 
     # adapted from https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/REPLCompletions.jl#L86-L95
+    # enables `ModuleCompletion` for local bindings
     function filtered_mod_names(ffunc::Function, mod::Module, name::AbstractString, all::Bool = false, imported::Bool = false)
       ssyms = names(mod, all = all, imported = imported)
       filter!(ffunc, ssyms)

--- a/src/debugger/debugger.jl
+++ b/src/debugger/debugger.jl
@@ -18,49 +18,9 @@ module JunoDebugger
 using ..Atom, MacroTools, Lazy, Hiccup
 
 include("breakpoints.jl")
-include("repl.jl")
 include("stepper.jl")
+include("repl.jl")
 include("workspace.jl")
 include("datatip.jl")
-
-function __init__()
-  # @HACK: overwriting these functions enables completions including local bindings while dubugging
-  @eval begin
-    import REPL.REPLCompletions: get_value, filtered_mod_names
-    using REPL.REPLCompletions: appendmacro!, completes_global, ModuleCompletion
-    using JuliaInterpreter: locals
-
-    # adapted from https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/REPLCompletions.jl#L348
-    # enables `MethodCompletion`, `PropertyCompletion`, `FieldCompletion` including local bindings
-    function get_value(sym::Symbol, fn)
-      # first look up local bindings
-      if isdebugging()
-        for var in STATE.locals
-          sym === var.name && return var.value, true
-        end
-      end
-      return isdefined(fn, sym) ? (getfield(fn, sym), true) : (nothing, false)
-    end
-
-    # adapted from https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/REPLCompletions.jl#L86-L95
-    # enables `ModuleCompletion` for local bindings
-    function filtered_mod_names(ffunc::Function, mod::Module, name::AbstractString, all::Bool = false, imported::Bool = false)
-      ssyms = names(mod, all = all, imported = imported)
-      filter!(ffunc, ssyms)
-      syms = String[string(s) for s in ssyms]
-
-      # inject local names for `ModuleCompletion`s
-      if isdebugging()
-        @>> map(v -> string(v.name), STATE.locals) append!(syms)
-      end
-
-      macros =  filter(x -> startswith(x, "@" * name), syms)
-      appendmacro!(syms, macros, "_str", "\"")
-      appendmacro!(syms, macros, "_cmd", "`")
-      filter!(x->completes_global(x, name), syms)
-      return [ModuleCompletion(mod, sym) for sym in syms]
-    end
-  end
-end
 
 end # module

--- a/src/debugger/debugger.jl
+++ b/src/debugger/debugger.jl
@@ -5,7 +5,7 @@ function enter(mod, ex; initial_continue = false)
     if inREPL[]
       JunoDebugger.enter(mod, ex; initial_continue = initial_continue)
     else
-      Base.printstyled(stderr, "Please run the debugger/interpreter in the REPL.\n", color=Base.error_color())
+      Base.printstyled(stderr, "Please run the debugger/interpreter in the REPL.\n", color = Base.error_color())
     end
   end
 end
@@ -22,5 +22,49 @@ include("repl.jl")
 include("stepper.jl")
 include("workspace.jl")
 include("datatip.jl")
+
+function __init__()
+  # @HACK: overwriting these functions enables completions including local bindings while dubugging
+  @eval begin
+    import REPL.REPLCompletions: get_value, filtered_mod_names
+    using REPL.REPLCompletions: appendmacro!, completes_global, ModuleCompletion
+    using JuliaInterpreter: locals
+
+    # adapted from https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/REPLCompletions.jl#L348
+    function get_value(sym::Symbol, fn)
+      isdefined(fn, sym) && return getfield(fn, sym), true
+
+      # enables `MethodCompletion`, `PropertyCompletion`, `FieldCompletion` including local bindings
+      if isdebugging()
+        global STATE
+        vars = locals(STATE.frame)
+        for var in vars
+          sym === var.name && return var.value, true
+        end
+      end
+
+      return (nothing, false)
+    end
+
+    # adapted from https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/REPLCompletions.jl#L86-L95
+    function filtered_mod_names(ffunc::Function, mod::Module, name::AbstractString, all::Bool = false, imported::Bool = false)
+      ssyms = names(mod, all = all, imported = imported)
+      filter!(ffunc, ssyms)
+      syms = String[string(s) for s in ssyms]
+
+      # inject local names for `ModuleCompletion`s
+      if isdebugging()
+        global STATE
+        @>> locals(STATE.frame) map(v -> string(v.name)) append!(syms)
+      end
+
+      macros =  filter(x -> startswith(x, "@" * name), syms)
+      appendmacro!(syms, macros, "_str", "\"")
+      appendmacro!(syms, macros, "_cmd", "`")
+      filter!(x->completes_global(x, name), syms)
+      return [ModuleCompletion(mod, sym) for sym in syms]
+    end
+  end
+end
 
 end # module

--- a/src/debugger/debugger.jl
+++ b/src/debugger/debugger.jl
@@ -54,7 +54,6 @@ function __init__()
 
       # inject local names for `ModuleCompletion`s
       if isdebugging()
-        global STATE
         @>> locals(STATE.frame) map(v -> string(v.name)) append!(syms)
       end
 

--- a/src/debugger/repl.jl
+++ b/src/debugger/repl.jl
@@ -65,7 +65,6 @@ function LineEdit.complete_line(c::JunoDebuggerRPELCompletionProvider, s)
   partial = REPL.beforecursor(s.input_buffer)
   full = LineEdit.input_string(s)
 
-  global STATE
   frame = STATE.frame
 
   # module-aware repl backend completions
@@ -73,9 +72,7 @@ function LineEdit.complete_line(c::JunoDebuggerRPELCompletionProvider, s)
   ret = map(REPLCompletions.completion_text, comps) |> unique!
 
   # make local completions appear first: verbose ?
-  vars = @>> filter!(locals(frame)) do v
-    return !(v.name == Symbol("#self") && (v.value isa Type || sizeof(v.value) == 0))
-  end map(v -> string(v.name))
+  vars = @>> locals(frame) map(v -> string(v.name))
   inds = []
   comps = []
   for (i, c) ∈ enumerate(ret)

--- a/src/debugger/repl.jl
+++ b/src/debugger/repl.jl
@@ -2,6 +2,7 @@ using REPL
 using REPL.LineEdit
 using REPL.REPLCompletions
 using JuliaInterpreter: moduleof, locals, eval_code
+import ..Atom: @msg
 
 const normal_prefix = Sys.iswindows() ? "\e[33m" : "\e[38;5;166m"
 const compiled_prefix = "\e[96m"
@@ -26,12 +27,12 @@ function debugprompt()
         REPL.LineEdit.reset_state(s)
         return false
       end
-      Atom.msg("working")
+      @msg working()
 
       line = String(take!(buf))
 
       if isempty(line)
-        Atom.msg("doneWorking")
+        @msg doneWorking()
         return true
       end
 
@@ -44,8 +45,8 @@ function debugprompt()
       println()
       LineEdit.reset_state(s)
 
-      Atom.msg("doneWorking")
-      Atom.msg("updateWorkspace")
+      @msg doneWorking()
+      @msg updateWorkspace()
 
       return true
     end
@@ -54,8 +55,8 @@ function debugprompt()
 
     REPL.run_interface(Base.active_repl.t, REPL.LineEdit.ModalInterface([panel, search_prompt]))
   catch e
-    Atom.msg("doneWorking")
-    Atom.msg("updateWorkspace")
+    @msg doneWorking()
+    @msg updateWorkspace()
     e isa InterruptException || rethrow(e)
   end
 end
@@ -64,11 +65,11 @@ end
 
 struct JunoDebuggerRPELCompletionProvider <: REPL.CompletionProvider end
 
-function LineEdit.complete_line(c::JunoDebuggerRPELCompletionProvider, s)
+function LineEdit.complete_line(c::JunoDebuggerRPELCompletionProvider, s, state::DebuggerState = STATE)
   partial = REPL.beforecursor(s.input_buffer)
   full = LineEdit.input_string(s)
 
-  frame = STATE.frame
+  frame = active_frame(state)
 
   # module-aware repl backend completions
   comps, range, should_complete = REPLCompletions.completions(full, lastindex(partial), moduleof(frame))

--- a/src/debugger/repl.jl
+++ b/src/debugger/repl.jl
@@ -1,7 +1,7 @@
 using REPL
 using REPL.LineEdit
 using REPL.REPLCompletions
-using JuliaInterpreter: locals
+using JuliaInterpreter: moduleof
 
 const normal_prefix = Sys.iswindows() ? "\e[33m" : "\e[38;5;166m"
 const compiled_prefix = "\e[96m"
@@ -65,14 +65,12 @@ function LineEdit.complete_line(c::JunoDebuggerRPELCompletionProvider, s)
   partial = REPL.beforecursor(s.input_buffer)
   full = LineEdit.input_string(s)
 
-  frame = STATE.frame
-
   # module-aware repl backend completions
-  comps, range, should_complete = REPLCompletions.completions(full, lastindex(partial), moduleof(frame))
+  comps, range, should_complete = REPLCompletions.completions(full, lastindex(partial), moduleof(STATE.frame))
   ret = map(REPLCompletions.completion_text, comps) |> unique!
 
   # make local completions appear first: verbose ?
-  vars = @>> locals(frame) map(v -> string(v.name))
+  vars = map(v -> string(v.name), STATE.locals)
   inds = []
   comps = []
   for (i, c) ∈ enumerate(ret)

--- a/src/debugger/repl.jl
+++ b/src/debugger/repl.jl
@@ -1,0 +1,85 @@
+using REPL
+using REPL.LineEdit
+using REPL.REPLCompletions
+
+const normal_prefix = Sys.iswindows() ? "\e[33m" : "\e[38;5;166m"
+const compiled_prefix = "\e[96m"
+
+function debugprompt()
+  try
+    panel = REPL.LineEdit.Prompt("debug> ";
+              prompt_prefix = isCompileMode() ? compiled_prefix : normal_prefix,
+              prompt_suffix = Base.text_colors[:normal],
+              complete = DebugCompletionProvider(),
+              on_enter = s -> true)
+
+    panel.hist = REPL.REPLHistoryProvider(Dict{Symbol,Any}(:junodebug => panel))
+    REPL.history_reset_state(panel.hist)
+
+    search_prompt, skeymap = LineEdit.setup_search_keymap(panel.hist)
+    search_prompt.complete = REPL.LatexCompletions()
+
+    panel.on_done = (s, buf, ok) -> begin
+      if !ok
+        LineEdit.transition(s, :abort)
+        REPL.LineEdit.reset_state(s)
+        return false
+      end
+      Atom.msg("working")
+
+      line = String(take!(buf))
+
+      isempty(line) && return true
+
+      try
+        r = Atom.JunoDebugger.interpret(line)
+        r ≠ nothing && display(r)
+      catch err
+        display_error(stderr, err, stacktrace(catch_backtrace()))
+      end
+      println()
+      LineEdit.reset_state(s)
+
+      Atom.msg("doneWorking")
+      Atom.msg("updateWorkspace")
+
+      return true
+    end
+
+    panel.keymap_dict = LineEdit.keymap(Dict{Any,Any}[skeymap, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults])
+
+    REPL.run_interface(Base.active_repl.t, REPL.LineEdit.ModalInterface([panel, search_prompt]))
+  catch e
+    Atom.msg("doneWorking")
+    Atom.msg("updateWorkspace")
+    e isa InterruptException || rethrow(e)
+  end
+end
+
+# repl completions
+
+struct DebugCompletionProvider <: REPL.CompletionProvider end
+
+function LineEdit.complete_line(c::DebugCompletionProvider, s)
+  partial = REPL.beforecursor(s.input_buffer)
+  full = LineEdit.input_string(s)
+
+  global STATE
+  frame = STATE.frame
+
+  # repl backend completions
+  comps, range, should_complete = REPLCompletions.completions(full, lastindex(partial), moduleof(frame))
+  ret = map(REPLCompletions.completion_text, comps) |> unique!
+
+  # local completions
+  @>> filter!(JuliaInterpreter.locals(frame)) do v
+    # ref: https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/master/src/utils.jl#L365-L370
+    if v.name == Symbol("#self") && (v.value isa Type || sizeof(v.value) == 0)
+      return false
+    else
+      return startswith(string(v.name), partial)
+    end
+  end map(v -> string(v.name)) vars -> pushfirst!(ret, vars...)
+
+  return ret, partial[range], should_complete
+end

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -1,9 +1,8 @@
 using JuliaInterpreter: pc_expr, moduleof, linenumber, extract_args, debug_command,
                         root, caller, whereis, get_return, nstatements, @lookup, Frame
 import JuliaInterpreter
-import ..Atom: fullpath, handle, @msg, wsitem, Inline, EvalError, Console, display_error, strlimit
-import Juno: Row, Tree
-using Media
+import ..Atom: fullpath, handle, @msg, Inline, display_error
+import Juno: Row
 using MacroTools
 
 mutable struct DebuggerState
@@ -184,91 +183,6 @@ function startdebugging(frame, initial_continue = false)
   res
 end
 
-using REPL
-using REPL.LineEdit
-using REPL.REPLCompletions
-
-const normal_prefix = Sys.iswindows() ? "\e[33m" : "\e[38;5;166m"
-const compiled_prefix = "\e[96m"
-
-function debugprompt()
-  try
-    panel = REPL.LineEdit.Prompt("debug> ";
-              prompt_prefix = isCompileMode() ? compiled_prefix : normal_prefix,
-              prompt_suffix = Base.text_colors[:normal],
-              complete = DebugCompletionProvider(),
-              on_enter = s -> true)
-
-    panel.hist = REPL.REPLHistoryProvider(Dict{Symbol,Any}(:junodebug => panel))
-    REPL.history_reset_state(panel.hist)
-
-    search_prompt, skeymap = LineEdit.setup_search_keymap(panel.hist)
-    search_prompt.complete = REPL.LatexCompletions()
-
-    panel.on_done = (s, buf, ok) -> begin
-      if !ok
-        LineEdit.transition(s, :abort)
-        REPL.LineEdit.reset_state(s)
-        return false
-      end
-      Atom.msg("working")
-
-      line = String(take!(buf))
-
-      isempty(line) && return true
-
-      try
-        r = Atom.JunoDebugger.interpret(line)
-        r ≠ nothing && display(r)
-      catch err
-        display_error(stderr, err, stacktrace(catch_backtrace()))
-      end
-      println()
-      LineEdit.reset_state(s)
-
-      Atom.msg("doneWorking")
-      Atom.msg("updateWorkspace")
-
-      return true
-    end
-
-    panel.keymap_dict = LineEdit.keymap(Dict{Any,Any}[skeymap, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults])
-
-    REPL.run_interface(Base.active_repl.t, REPL.LineEdit.ModalInterface([panel, search_prompt]))
-  catch e
-    Atom.msg("doneWorking")
-    Atom.msg("updateWorkspace")
-    e isa InterruptException || rethrow(e)
-  end
-end
-
-struct DebugCompletionProvider <: REPL.CompletionProvider end
-
-function LineEdit.complete_line(c::DebugCompletionProvider, s)
-  partial = REPL.beforecursor(s.input_buffer)
-  full = LineEdit.input_string(s)
-
-  global STATE
-  frame = STATE.frame
-
-  # repl backend completions
-  comps, range, should_complete = REPLCompletions.completions(full, lastindex(partial), moduleof(frame))
-  ret = map(REPLCompletions.completion_text, comps) |> unique!
-
-  # local completions
-  vars = filter!(JuliaInterpreter.locals(frame)) do v
-    # ref: https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/master/src/utils.jl#L365-L370
-    if v.name == Symbol("#self") && (v.value isa Type || sizeof(v.value) == 0)
-      return false
-    else
-      return startswith(string(v.name), partial)
-    end
-  end |> vars -> map(v -> string(v.name), vars)
-  pushfirst!(ret, vars...)
-
-  return ret, partial[range], should_complete
-end
-
 # setup handlers for stepper commands
 for cmd in [:nextline, :stepin, :stepexpr, :finish, :stop, :continue]
   handle(()->put!(chan[], cmd), string(cmd))
@@ -332,7 +246,6 @@ function stack(frame)
   end
   reverse(ctx)
 end
-
 
 """
     get_code_around(file, line, frame; around = 3)
@@ -411,77 +324,6 @@ function evalscope(f)
     lock(Atom.evallock)
     @msg working()
   end
-end
-
-## Workspace
-function contexts(s::DebuggerState = STATE)
-  s.frame === nothing && return []
-  ctx = []
-  trace = ""
-  frame = root(s.frame)
-  while frame ≠ nothing
-    trace = string(trace, "/", frame.framecode.scope isa Method ?
-                                frame.framecode.scope.name : "???")
-    c = Dict(:context => string("Debug: ", trace), :items => localvars(frame))
-    pushfirst!(ctx, c)
-
-    frame = frame.callee
-  end
-  ctx
-end
-
-function localvars(frame)
-  vars = JuliaInterpreter.locals(frame)
-  items = []
-  scope = frame.framecode.scope
-  mod = scope isa Module ? scope : scope.module
-  for v in vars
-    # ref: https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/master/src/utils.jl#L365-L370
-    v.name == Symbol("#self#") && (isa(v.value, Type) || sizeof(v.value) == 0) && continue
-    push!(items, wsitem(mod, v.name, v.value))
-  end
-  items
-end
-
-handle("setStackLevel") do level
-  with_error_message() do
-    level = level isa String ? parseInt(level) : level
-    STATE.level = level
-    stepto(active_frame(STATE), level)
-    nothing
-  end
-end
-
-## Datatip
-
-using CodeTracking
-
-function datatip(word, path, row, column, s::DebuggerState = STATE)
-  frame = s.frame
-
-  # frame validation & only work for methods
-  scope = frame.framecode.scope
-  if frame === nothing || scope isa Module
-    return nothing
-  end
-
-  # path identity check
-  path != JuliaInterpreter.getfile(frame) && return nothing
-
-  # line number check
-  defstr, startline = definition(String, scope)
-  endline = startline + sum(c === '\n' for c in defstr)
-  startline <= row <= endline || return nothing
-
-  # local bindings
-  for v in JuliaInterpreter.locals(frame)
-    if string(v.name) === word
-      valstr = @> repr(MIME("text/plain"), v.value, context = :limit => true) strlimit(1000, " ...")
-      return [Dict(:type  => :snippet, :value => valstr)]
-    end
-  end
-
-  return nothing # when no local binding exists
 end
 
 ## Evaluation

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -324,9 +324,3 @@ function evalscope(f)
     @msg working()
   end
 end
-
-## Evaluation
-function interpret(code::AbstractString, s::DebuggerState = STATE)
-  s.frame === nothing && return
-  JuliaInterpreter.eval_code(active_frame(s), code)
-end

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -1,5 +1,6 @@
-using JuliaInterpreter: pc_expr, moduleof, linenumber, extract_args, debug_command,
-                        root, caller, whereis, get_return, nstatements, @lookup, Frame
+using JuliaInterpreter: pc_expr, extract_args, debug_command, root, caller,
+                        whereis, get_return, @lookup, locals,
+                        Frame, Variable
 import JuliaInterpreter
 import ..Atom: fullpath, handle, @msg, Inline, display_error
 import Juno: Row
@@ -7,11 +8,12 @@ using MacroTools
 
 mutable struct DebuggerState
   frame::Union{Nothing, Frame}
+  locals::Vector{Variable} # better to be kept here to avoid duplicated computations for the same frame
   broke_on_error::Bool
   level::Int
 end
-DebuggerState(frame::Frame) = DebuggerState(frame, false, 1)
-DebuggerState() = DebuggerState(nothing, false, 1)
+DebuggerState(frame::Frame) = DebuggerState(frame, locals(frame), false, 1)
+DebuggerState() = DebuggerState(nothing, [], false, 1)
 
 function active_frame(state::DebuggerState)
   frame = state.frame
@@ -97,6 +99,7 @@ function startdebugging(frame, initial_continue = false)
           return res = JuliaInterpreter.get_return(root(frame))
         end
         STATE.frame = frame = ret[1]
+        STATE.locals = locals(frame)
         pc = ret[2]
         if pc isa JuliaInterpreter.BreakpointRef && pc.err !== nothing
           STATE.broke_on_error = true
@@ -157,6 +160,7 @@ function startdebugging(frame, initial_continue = false)
           break
         else
           STATE.frame = frame = ret[1]
+          STATE.locals = locals(frame)
           STATE.level = stacklength(STATE) - 1
           pc = ret[2]
           if pc isa JuliaInterpreter.BreakpointRef && pc.err !== nothing

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -80,10 +80,9 @@ function startdebugging(frame, initial_continue = false)
   if frame === nothing
     error("failed to enter the function, perhaps it is set to run in compiled mode")
   end
-  global STATE
   STATE.frame = frame
   STATE.broke_on_error = false
-  global chan[] = Channel(0)
+  chan[] = Channel(0)
 
   temp_bps = add_breakpoint.(Atom.rpc("getFileBreakpoints"))
 

--- a/src/debugger/stepper.jl
+++ b/src/debugger/stepper.jl
@@ -1,6 +1,5 @@
 using JuliaInterpreter: pc_expr, extract_args, debug_command, root, caller,
-                        whereis, get_return, @lookup, locals,
-                        Frame, Variable
+                        whereis, get_return, @lookup, Frame
 import JuliaInterpreter
 import ..Atom: fullpath, handle, @msg, Inline, display_error
 import Juno: Row
@@ -8,12 +7,11 @@ using MacroTools
 
 mutable struct DebuggerState
   frame::Union{Nothing, Frame}
-  locals::Vector{Variable} # better to be kept here to avoid duplicated computations for the same frame
   broke_on_error::Bool
   level::Int
 end
-DebuggerState(frame::Frame) = DebuggerState(frame, locals(frame), false, 1)
-DebuggerState() = DebuggerState(nothing, [], false, 1)
+DebuggerState(frame::Frame) = DebuggerState(frame, false, 1)
+DebuggerState() = DebuggerState(nothing, false, 1)
 
 function active_frame(state::DebuggerState)
   frame = state.frame
@@ -99,7 +97,6 @@ function startdebugging(frame, initial_continue = false)
           return res = JuliaInterpreter.get_return(root(frame))
         end
         STATE.frame = frame = ret[1]
-        STATE.locals = locals(frame)
         pc = ret[2]
         if pc isa JuliaInterpreter.BreakpointRef && pc.err !== nothing
           STATE.broke_on_error = true
@@ -160,7 +157,6 @@ function startdebugging(frame, initial_continue = false)
           break
         else
           STATE.frame = frame = ret[1]
-          STATE.locals = locals(frame)
           STATE.level = stacklength(STATE) - 1
           pc = ret[2]
           if pc isa JuliaInterpreter.BreakpointRef && pc.err !== nothing

--- a/src/debugger/workspace.jl
+++ b/src/debugger/workspace.jl
@@ -1,4 +1,4 @@
-using JuliaInterpreter: root, locals, moduleof
+using JuliaInterpreter: root, locals, moduleof, callee
 import ..Atom: wsitem, handle
 
 function contexts(state::DebuggerState = STATE)
@@ -6,7 +6,8 @@ function contexts(state::DebuggerState = STATE)
   ctx = []
   trace = ""
   frame = root(state.frame)
-  while frame ≠ nothing
+  active_callee = callee(active_frame(state))
+  while frame ≠ nothing && frame ≠ active_callee
     trace = string(trace, "/", frame.framecode.scope isa Method ?
                                 frame.framecode.scope.name : "???")
     c = Dict(:context => string("Debug: ", trace), :items => localvars(frame))
@@ -31,13 +32,4 @@ function localvars(frame)
     push!(items, item)
   end
   items
-end
-
-handle("setStackLevel") do level
-  with_error_message() do
-    level = level isa String ? parseInt(level) : level
-    STATE.level = level
-    stepto(active_frame(STATE), level)
-    nothing
-  end
 end

--- a/src/debugger/workspace.jl
+++ b/src/debugger/workspace.jl
@@ -1,11 +1,11 @@
 using JuliaInterpreter: root, locals, moduleof
 import ..Atom: wsitem, handle
 
-function contexts(s::DebuggerState = STATE)
-  s.frame === nothing && return []
+function contexts(state::DebuggerState = STATE)
+  state.frame === nothing && return []
   ctx = []
   trace = ""
-  frame = root(s.frame)
+  frame = root(state.frame)
   while frame ≠ nothing
     trace = string(trace, "/", frame.framecode.scope isa Method ?
                                 frame.framecode.scope.name : "???")

--- a/src/debugger/workspace.jl
+++ b/src/debugger/workspace.jl
@@ -24,7 +24,11 @@ function localvars(frame)
   for v in vars
     # ref: https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/master/src/utils.jl#L365-L370
     v.name == Symbol("#self#") && (isa(v.value, Type) || sizeof(v.value) == 0) && continue
-    push!(items, wsitem(mod, v.name, v.value))
+    item = wsitem(mod, v.name, v.value)
+    # Julia doesn't support "constantness" for local variables
+    item[:type] == "constant" && (item[:type] = "variable")
+    item[:icon] == "c" && (item[:icon] = "v")
+    push!(items, item)
   end
   items
 end

--- a/src/debugger/workspace.jl
+++ b/src/debugger/workspace.jl
@@ -1,4 +1,4 @@
-using JuliaInterpreter: root, locals
+using JuliaInterpreter: root, locals, moduleof
 import ..Atom: wsitem, handle
 
 function contexts(s::DebuggerState = STATE)
@@ -20,8 +20,7 @@ end
 function localvars(frame)
   vars = locals(frame)
   items = []
-  scope = frame.framecode.scope
-  mod = scope isa Module ? scope : scope.module
+  mod = moduleof(frame)
   for v in vars
     # ref: https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/master/src/utils.jl#L365-L370
     v.name == Symbol("#self#") && (isa(v.value, Type) || sizeof(v.value) == 0) && continue

--- a/src/debugger/workspace.jl
+++ b/src/debugger/workspace.jl
@@ -1,0 +1,40 @@
+using JuliaInterpreter: root, locals
+import ..Atom: wsitem, handle
+
+function contexts(s::DebuggerState = STATE)
+  s.frame === nothing && return []
+  ctx = []
+  trace = ""
+  frame = root(s.frame)
+  while frame ≠ nothing
+    trace = string(trace, "/", frame.framecode.scope isa Method ?
+                                frame.framecode.scope.name : "???")
+    c = Dict(:context => string("Debug: ", trace), :items => localvars(frame))
+    pushfirst!(ctx, c)
+
+    frame = frame.callee
+  end
+  ctx
+end
+
+function localvars(frame)
+  vars = locals(frame)
+  items = []
+  scope = frame.framecode.scope
+  mod = scope isa Module ? scope : scope.module
+  for v in vars
+    # ref: https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/master/src/utils.jl#L365-L370
+    v.name == Symbol("#self#") && (isa(v.value, Type) || sizeof(v.value) == 0) && continue
+    push!(items, wsitem(mod, v.name, v.value))
+  end
+  items
+end
+
+handle("setStackLevel") do level
+  with_error_message() do
+    level = level isa String ? parseInt(level) : level
+    STATE.level = level
+    stepto(active_frame(STATE), level)
+    nothing
+  end
+end


### PR DESCRIPTION
Mainly I did two things on this branch:
1. separate stepper.jl into appropriate sub files (since stepper.jl's got so fat)
2. enable "complete" completions within debug REPL: e.g.:
    * `MethodCompletion` including local bindings: `strlimit(localstring, |` should show `MethodCompletion`s for `strlimit(str::String, ...)`
    * `PropertyCompletion` for local bindings: `localobj.|` should show the properties of `localobj`
    * etc...

A part that needs to be reviewed is obviously around 2 -- it's doing [such a hacky/dirty thing](https://github.com/JunoLab/Atom.jl/blob/01c215ba246e9c0d3a159b045b829f0533d8a9bf/src/debugger/debugger.jl#L26-L67) (overwriting the methods within REPL module)
This implementation is not so robust to future changes within `REPLCompletion` module, but imho I suspect we can detect future regressions easily, since now we have kinda rich tests for that. Still you may think this implementation is not good in terms of maintenance though.

As for the refactors around 1, I just move the code and removed unnecessary imports carefully.
 
***

UPDATE:

This PR only does several refactors around `Atom.JunoDebugger`, and the hacks on `REPLCompletions` are discarded.
If anyone interested in that, visit [my startup script](https://github.com/aviatesk/avi-atom/blob/master/scripts/junostartup.jl#L45-L83)

Refactors:
1. separate stepper.jl into appropriate sub files (since stepper.jl's got so fat)
2. suppress constantness iconography within debug workspace items: Julia doesn't support explicit constantness for local variables
3. send `doneWorking` message if a sent line is empty within debug repl
4. make debug datatip works for base funcitons