### PR TITLE
more refactors on completions.jl

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -116,6 +116,8 @@ function strlimit(str::AbstractString, limit::Int = 30, ellipsis::AbstractString
   return String(take!(io))
 end
 
+shortstr(val) = strlimit(string(val), 20)
+
 # singleton type for undefined values
 struct Undefined end
 
@@ -155,3 +157,6 @@ getdocs(mod::Module, word::String) = begin
   md_hlines(md)
 end
 getdocs(mod::String, word::String) = getdocs(getmodule(mod), word)
+
+cangetdocs(mod::Module, word::Symbol) = Base.isbindingresolved(mod, word) && !Base.isdeprecated(mod, word)
+cangetdocs(mod::Module, word::String) = cangetdocs(mod, Symbol(word))

--- a/test/completions.jl
+++ b/test/completions.jl
@@ -96,7 +96,7 @@
         @test map(comps("split(\"\", \"\")[1].")) do c
             c[:type] == "property" &&
             c[:rightLabel] == "SubString{String}" &&
-            c[:leftLabel] ∈ string.(fieldtypes(SubString{String})) &&
+            c[:leftLabel] ∈ string.(ntuple(i -> fieldtype(SubString{String}, i), fieldcount(SubString{String}))) &&
             c[:text] ∈ string.(fieldnames(SubString{String}))
         end |> all
     end


### PR DESCRIPTION
- simplify the whole logic in `completion(mod, c)`
- `returntype` -> `completionreturntype`
- enhance `DictCompletion`
  * show value type
  * add icon/type
- enhance `FieldCompletion`
  * show a predicted type in rightLabel
- fix the logic `completiontext(::MethodCompletion)` for a case when the regex does not match
- `shortstr` function
- move `cangetdocs` into utils.jl
- don't use `handle` in tests
- add more test cases