### PR TITLE
improve error printing

### DIFF
--- a/src/display/errors.jl
+++ b/src/display/errors.jl
@@ -29,6 +29,12 @@ function Base.show(io::IO, err::EvalError)
   end
 end
 
+function Base.showerror(io::IO, err::EvalError)
+  printstyled(io, "ERROR: "; bold=true, color=Base.error_color())
+  Base.showerror(io, err.err, cliptrace(err.trace))
+  println(io)
+end
+
 const MAX_STACKTRACE_LENGTH = 100
 const STACKTRACE_END_LENGTH = 30
 


### PR DESCRIPTION
and add an option to always show errors in REPL when using inline evaluation.

Fixes https://github.com/JunoLab/Juno.jl/issues/381.