### PR TITLE
fixes JunoLab/Juno.jl#404

### DIFF
--- a/test/outline.jl
+++ b/test/outline.jl
@@ -131,6 +131,24 @@
         end
     end
 
+    # detect all the method parameters of a method with a `where` clause
+    let str = """
+        function push!′(ary::Vector{T}, item::S) where {T, S<:T}
+            tmpvec, tmpitem = ary, item
+            push!(tmpvec, tmpitem)
+        end
+        """
+
+        binds = map(l -> l[:name], Atom.locals(str, 1, 0))
+        @test "ary" in binds
+        @test "item" in binds
+        @test "T" in binds
+        @test "S" in binds
+        @test "tmpvec" in binds
+        @test "tmpitem" in binds
+        @test "push!′" in binds
+    end
+
     let str = """
         function foo(x)
             @macrocall begin


### PR DESCRIPTION
A `where` clause creates `LocalScope`, which holds method arguments as its children, but `_actual_local_bindings` fails to enter into its children on https://github.com/JunoLab/Atom.jl/blob/1f9cf9db6020a84a5b7430850d2cd8c9bf1cd35c/src/outline.jl#L303

Fixes via the same approach as https://github.com/JunoLab/Atom.jl/pull/183