### PR TITLE
strip trailing dots in goto/datatip (and rename)

### DIFF
--- a/src/datatip.jl
+++ b/src/datatip.jl
@@ -1,7 +1,6 @@
 #=
-@TODO:
-Use our own UI components for this: atom-ide-ui is already deprecated, ugly, not fully functional, and and...
-Once we can come to handle links within datatips, we may want to append method tables as well
+@TODO use our own UI components for this:
+atom-ide-ui is already deprecated, ugly, not fully functional, and and...
 =#
 
 handle("datatip") do data
@@ -74,6 +73,9 @@ function globaldatatip(mod, word, fullword)
 
   processdoc!(docs, docstr, datatip)
 
+  ml = methods(val)
+  processmethods!(ml, datatip)
+
   return datatip
 end
 
@@ -124,6 +126,20 @@ processval!(val::Function, docstr, datatip) = begin
   occursin(valstr, docstr) || pushsnippet!(datatip, valstr)
 end
 processval!(::Undefined, docstr, datatip) = nothing
+
+function processmethods!(ml, datatip)
+  ms = collect(ml)
+  isempty(ms) && return
+
+  substr = s"<code>\g<sig></code> in <code>\g<mod></code> at \g<loc>"
+  msstr = map(ms) do m
+    s = replace(string(m), methodloc_regex => substr)
+    "<li>$s</li>"
+  end |> join
+
+  name = ms[1].name
+  pushmarkdown!(datatip, "<details><summary><code>$name</code> has **$(length(ms))** methods:</summary><ul>$(msstr)</ul></details>")
+end
 
 function pushmarkdown!(datatip, markdown)
   (markdown == "" || markdown == "\n") && return

--- a/src/display/methods.jl
+++ b/src/display/methods.jl
@@ -4,9 +4,11 @@ stripparams(t) = replace(t, r"\{([A-Za-z, ]*?)\}" => "")
 
 interpose(xs, y) = map(i -> iseven(i) ? xs[i÷2] : y, 2:2length(xs))
 
+const methodloc_regex = r"(?<sig>.+) in (?<mod>.+) at (?<loc>.+)$"
+
 function view(m::Method)
   str = sprint(show, "text/html", m)
-  str = replace(str, r" in .* at .*$" => "")
+  str = replace(str, methodloc_regex => s"\g<sig>")
   str = string("<span>", str, "</span>")
   tv, decls, file, line = Base.arg_decl_parts(m)
   HTML(str), file == :null ? "not found" : Atom.baselink(string(file), line)

--- a/src/goto.jl
+++ b/src/goto.jl
@@ -86,40 +86,6 @@ localgotoitem(word, ::Nothing, column, row, startrow, context) = [] # when `path
 function globalgotoitems(word, mod, text, path)
   mod = getmodule(mod)
 
-  moduleitems = modulegotoitems(word, mod)
-  isempty(moduleitems) || return moduleitems
-
-  toplevelitems = toplevelgotoitems(word, mod, text, path)
-
-  # only append methods that are not caught by `toplevelgotoitems`
-  files = map(item -> item.file, toplevelitems)
-  methoditems = filter!(item -> item.file ∉ files, methodgotoitems(mod, word))
-
-  append!(toplevelitems, methoditems)
-end
-
-## module goto
-
-function modulegotoitems(word, mod)::Vector{GotoItem}
-  mod = getfield′(mod, Symbol(word))
-  return mod isa Module ? [GotoItem(mod)] : []
-end
-
-function GotoItem(mod::Module)
-  file, line = if mod == Main
-    MAIN_MODULE_LOCATION[]
-  else
-    moduledefinition(mod)
-  end
-  GotoItem(string(mod), file, line - 1)
-end
-
-## toplevel goto
-
-const PathItemsMaps = Dict{String, Vector{ToplevelItem}}
-const SYMBOLSCACHE = Dict{String, PathItemsMaps}()
-
-function toplevelgotoitems(word, mod, text, path)
   # strip a dot-accessed module if exists
   identifiers = split(word, '.')
   head = string(identifiers[1])
@@ -129,6 +95,31 @@ function toplevelgotoitems(word, mod, text, path)
     return globalgotoitems(nextword, head, text, path)
   end
 
+  val = getfield′(mod, word)
+  val isa Module && return [GotoItem(val)] # module goto
+
+  toplevelitems = toplevelgotoitems(word, mod, text, path)
+
+  # append method gotos that are not caught by `toplevelgotoitems`
+  ml = methods(val)
+  files = map(item -> item.file, toplevelitems)
+  methoditems = filter!(item -> item.file ∉ files, methodgotoitems(ml))
+  append!(toplevelitems, methoditems)
+end
+
+## module goto
+
+function GotoItem(mod::Module)
+  file, line = mod == Main ? MAIN_MODULE_LOCATION[] : moduledefinition(mod)
+  GotoItem(string(mod), file, line - 1)
+end
+
+## toplevel goto
+
+const PathItemsMaps = Dict{String, Vector{ToplevelItem}}
+const SYMBOLSCACHE = Dict{String, PathItemsMaps}()
+
+function toplevelgotoitems(word, mod, text, path)
   key = string(mod)
   pathitemsmaps = if haskey(SYMBOLSCACHE, key)
     SYMBOLSCACHE[key]
@@ -138,8 +129,8 @@ function toplevelgotoitems(word, mod, text, path)
 
   ismacro(word) && (word = lstrip(word, '@'))
   ret = Vector{GotoItem}()
-  for (path, items) ∈ pathitemsmaps
-    for item ∈ filter(item -> filtertoplevelitem(word, item), items)
+  for (path, items) in pathitemsmaps
+    for item in filter(item -> filtertoplevelitem(word, item), items)
       push!(ret, GotoItem(path, item))
     end
   end
@@ -168,7 +159,7 @@ end
 function _searchtoplevelitems(mod::Module, pathitemsmaps::PathItemsMaps)
   entrypath, paths = modulefiles(mod) # Revise-like approach
   if entrypath !== nothing
-    for p ∈ [entrypath; paths]
+    for p in [entrypath; paths]
       _searchtoplevelitems(p, pathitemsmaps)
     end
   else # if Revise-like approach fails, fallback to CSTParser-based approach
@@ -187,14 +178,13 @@ function _searchtoplevelitems(path::String, pathitemsmaps::PathItemsMaps)
   push!(pathitemsmaps, pathitemsmap)
 end
 
-# module-walk by CSTParser-based, looking for toplevel `installed` calls
+# module-walk based on CSTParser, looking for toplevel `installed` calls
 function _searchtoplevelitems(text::String, path::String, pathitemsmaps::PathItemsMaps)
   parsed = CSTParser.parse(text, true)
   items = toplevelitems(parsed, text)
-  pathitemsmap = path => items
-  push!(pathitemsmaps, pathitemsmap)
+  push!(pathitemsmaps, path => items)
 
-  # looking for toplevel `installed` calls
+  # looking for toplevel `include` calls
   for item in items
     if item isa ToplevelCall
       expr = item.expr
@@ -277,7 +267,7 @@ function regeneratesymbols()
   unloadedlen = length(unloaded)
   total = loadedlen + unloadedlen
 
-  for (i, mod) ∈ enumerate(Base.loaded_modules_array())
+  for (i, mod) in enumerate(Base.loaded_modules_array())
     try
       modstr = string(mod)
       modstr == "__PackagePrecompilationStatementModule" && continue # will cause error
@@ -291,7 +281,7 @@ function regeneratesymbols()
     end
   end
 
-  for (i, pkg) ∈ enumerate(unloaded)
+  for (i, pkg) in enumerate(unloaded)
     try
       path = Base.find_package(pkg)
       text = read(path, String)
@@ -310,27 +300,19 @@ end
 
 ## method goto
 
-function methodgotoitems(mod, word)::Vector{GotoItem}
-  ms = @errs getmethods(mod, word)
-  if ms isa EvalError
-    []
-  else
-    map(GotoItem, aggregatemethods(ms))
-  end
-end
+methodgotoitems(ml) = map(GotoItem, aggregatemethods(ml))
 
 # aggregate methods with default arguments to the ones with full arguments
-aggregatemethods(f) = aggregatemethods(methods(f))
-aggregatemethods(ms::MethodList) = aggregatemethods(collect(ms))
-function aggregatemethods(ms::Vector{Method})
-  ms = sort(ms, by = m -> m.nargs, rev = true)
-  unique(m -> (m.file, m.line), ms)
+function aggregatemethods(ml)
+  ms = collect(ml)
+  sort!(ms, by = m -> m.nargs, rev = true)
+  unique!(m -> (m.file, m.line), ms)
 end
 
 function GotoItem(m::Method)
   _, link = view(m)
   sig = sprint(show, m)
-  text = replace(sig, r" in .* at .*$" => "")
+  text = replace(sig, methodloc_regex => s"\g<sig>")
   file = link.file
   line = link.line - 1
   secondary = join(link.contents)

--- a/src/goto.jl
+++ b/src/goto.jl
@@ -306,7 +306,7 @@ methodgotoitems(ml) = map(GotoItem, aggregatemethods(ml))
 function aggregatemethods(ml)
   ms = collect(ml)
   sort!(ms, by = m -> m.nargs, rev = true)
-  unique!(m -> (m.file, m.line), ms)
+  unique(m -> (m.file, m.line), ms)
 end
 
 function GotoItem(m::Method)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -111,6 +111,15 @@ end
 # string utilties
 # ---------------
 
+"""
+    strlimit(str::AbstractString, limit::Int = 30, ellipsis::AbstractString = "…")
+
+Chops off `str` so that its _length_ doesn't exceed `limit`. The excessive part
+  will be replaced by `ellipsis`.
+
+!!! note
+    The length of returned string will _never_ exceed `limit`.
+"""
 function strlimit(str::AbstractString, limit::Int = 30, ellipsis::AbstractString = "…")
   will_append = length(str) > limit
 
@@ -129,6 +138,18 @@ function strlimit(str::AbstractString, limit::Int = 30, ellipsis::AbstractString
 end
 
 shortstr(val) = strlimit(string(val), 20)
+
+"""
+    striptrailingdots(word::AbstractString, fullword::AbstractString)
+
+Strips all the dot-accessors after `word` in `fullword`.
+"""
+function striptrailingdots(word::AbstractString, fullword::AbstractString)
+  words = split(fullword, '.')
+  ind = findfirst(w -> w == word, words)
+  ind === nothing && return word # invalid case
+  return join(words[1:ind], '.')
+end
 
 # singleton type for undefined values
 struct Undefined end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -140,18 +140,10 @@ end
 shortstr(val) = strlimit(string(val), 20)
 
 """
-    striptrailingdots(word::AbstractString, fullword::AbstractString)
+    Undefined
 
-Strips all the dot-accessors after `word` in `fullword`.
+singleton type representing undefined values
 """
-function striptrailingdots(word::AbstractString, fullword::AbstractString)
-  words = split(fullword, '.')
-  ind = findfirst(w -> w == word, words)
-  ind === nothing && return word # invalid case
-  return join(words[1:ind], '.')
-end
-
-# singleton type for undefined values
 struct Undefined end
 
 # get utilities

--- a/test/datatip.jl
+++ b/test/datatip.jl
@@ -19,7 +19,7 @@
             @test localdatatip("l", 4) == 3 # line
         end
 
-        # remove dot accessors
+        # ignore dot accessors
         let str = """
             function withdots(expr::CSTParser.EXPR)
                 bind = CSTParser.bindingof(expr.args[1])
@@ -68,8 +68,8 @@
         end
     end
 
-    @testset "toplevel datatips" begin
-        using Atom: topleveldatatip
+    @testset "global datatips" begin
+        using Atom: globaldatatip
 
         ## method datatip
         @eval Main begin
@@ -81,7 +81,7 @@
             datatipmethodtest() = nothing
         end
 
-        let datatip = topleveldatatip("Main", "datatipmethodtest")
+        let datatip = globaldatatip("Main", "datatipmethodtest", "datatipmethodtest")
             @test datatip isa Vector
             firsttip = datatip[1]
             secondtip = datatip[2]
@@ -94,11 +94,16 @@
         ## variable datatip
         @eval Main datatipvariabletest = "this string should be shown in datatip"
 
-        let datatip = topleveldatatip("Main", "datatipvariabletest")
+        let datatip = globaldatatip("Main", "datatipvariabletest", "datatipvariabletest")
             @test datatip isa Vector
             firsttip = datatip[1]
             @test firsttip[:type] == :snippet
             @test occursin(r"this string should be shown in datatip", firsttip[:value])
+        end
+
+        ## strips training dots
+        let item = globaldatatip("Atom", "SYMBOLSCACHE", "SYMBOLSCACHE")
+            @test item == globaldatatip("Atom", "SYMBOLSCACHE", "SYMBOLSCACHE.keys")
         end
     end
 end

--- a/test/datatip.jl
+++ b/test/datatip.jl
@@ -81,7 +81,7 @@
             datatipmethodtest() = nothing
         end
 
-        let datatip = globaldatatip("Main", "datatipmethodtest", "datatipmethodtest")
+        let datatip = globaldatatip("Main", "datatipmethodtest")
             @test datatip isa Vector
             firsttip = datatip[1]
             secondtip = datatip[2]
@@ -94,16 +94,11 @@
         ## variable datatip
         @eval Main datatipvariabletest = "this string should be shown in datatip"
 
-        let datatip = globaldatatip("Main", "datatipvariabletest", "datatipvariabletest")
+        let datatip = globaldatatip("Main", "datatipvariabletest")
             @test datatip isa Vector
             firsttip = datatip[1]
             @test firsttip[:type] == :snippet
             @test occursin(r"this string should be shown in datatip", firsttip[:value])
-        end
-
-        ## strips training dots
-        let item = globaldatatip("Atom", "SYMBOLSCACHE", "SYMBOLSCACHE")
-            @test item == globaldatatip("Atom", "SYMBOLSCACHE", "SYMBOLSCACHE.keys")
         end
     end
 end

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -1,8 +1,4 @@
 @testset "goto symbols" begin
-    using Atom: modulegotoitems, toplevelgotoitems, SYMBOLSCACHE,
-                regeneratesymbols, methodgotoitems, globalgotoitems
-    using CSTParser
-
     @testset "goto local symbols" begin
         let str = """
             function localgotoitem(word, path, column, row, startRow, context) # L0
@@ -49,201 +45,199 @@
         @test Atom.localgotoitem("word", nothing, 1, 1, 0, "") == []
     end
 
-    @testset "module goto" begin
-        let item = modulegotoitems("Atom", Main)[1]
-            @test item.file == joinpath′(atomjldir, "Atom.jl")
-            @test item.line == 3
-        end
-        let item = modulegotoitems("Junk2", Main.Junk)[1]
-            @test item.file == joinpath′(junkpath)
-            @test item.line == 14
-        end
-    end
+    @testset "goto global symbols" begin
+        using Atom: globalgotoitems, toplevelgotoitems, SYMBOLSCACHE,
+                    regeneratesymbols, methodgotoitems
 
-    @testset "goto toplevel symbols" begin
-        ## where Revise approach works, i.e.: precompiled modules
-        let path = joinpath′(atomjldir, "comm.jl")
-            text = read(path, String)
-            mod = Atom
-            key = "Atom"
-            word = "handlers"
-
-            # basic
-            let items = toplevelgotoitems(word, mod, text, path) .|> Dict
-                @test !isempty(items)
-                @test items[1][:file] == path
-                @test items[1][:text] == word
-            end
-
-            # check caching works
-            @test haskey(SYMBOLSCACHE, key)
-
-            # check the Revise-like approach finds all files in Atom module
-            @test length(SYMBOLSCACHE[key]) == length(atommodfiles)
-
-            # when `path` isn't given, i.e. via docpane / workspace
-            let items = toplevelgotoitems(word, mod, "", nothing) .|> Dict
-                @test !isempty(items)
-                @test items[1][:file] == path
-                @test items[1][:text] == word
-            end
-
-            # same as above, but without any previous cache -- falls back to CSTPraser-based module-walk
-            delete!(SYMBOLSCACHE, key)
-
-            let items = toplevelgotoitems(word, mod, "", nothing) .|> Dict
-                @test !isempty(items)
-                @test items[1][:file] == path
-                @test items[1][:text] == word
-            end
-
-            # check CSTPraser-based module-walk finds all the included files
-            # currently broken:
-            # - files in submodules are included
-            # - webio.jl is excluded since `include("webio.jl")` is a toplevel call
-            @test_broken length(SYMBOLSCACHE[key]) == length(atommoddir)
-        end
-
-        ## where the Revise-like approach doesn't work, e.g. non-precompiled modules
-        let path = junkpath
-            text = read(path, String)
-            mod = Main.Junk
-            key = "Main.Junk"
-            word = "toplevelval"
-
-            # basic
-            let items = toplevelgotoitems(word, mod, text, path) .|> Dict
-                @test !isempty(items)
-                @test items[1][:file] == path
-                @test items[1][:line] == 16
-                @test items[1][:text] == word
-            end
-
-            # check caching works
-            @test haskey(Atom.SYMBOLSCACHE, key)
-
-            # when `path` isn't given, i.e.: via docpane / workspace
-            let items = toplevelgotoitems(word, mod, "", nothing) .|> Dict
-                @test !isempty(items)
-                @test items[1][:file] == path
-                @test items[1][:line] == 16
-                @test items[1][:text] == word
-            end
-        end
-
-        # handle dot accessors gracefully
+        ## strip a dot-accessed modules
         let
-            # can access the non-exported (non-method) bindings in the other module
-            path = joinpath′(@__DIR__, "..", "src", "goto.jl")
-            text = read(@__FILE__, String)
-            items = Dict.(toplevelgotoitems("Atom.SYMBOLSCACHE", Main, text, @__FILE__))
-            @test !isempty(items)
-            @test items[1][:file] == path
-            @test items[1][:text] == "SYMBOLSCACHE"
-
-            # handle if a module is duplicated
             path = joinpath′(@__DIR__, "..", "src", "comm.jl")
             text = read(path, String)
-            items = Dict.(toplevelgotoitems("Atom.handlers", Atom, text, path))
+            items = Dict.(globalgotoitems("Atom.handlers", "Atom", text, path))
             @test !isempty(items)
             @test items[1][:file] == path
             @test items[1][:text] == "handlers"
-        end
-
-        # don't error on the fallback case
-        @test toplevelgotoitems("word", Main, "", nothing) == []
-    end
-
-    @testset "updating toplevel symbols" begin
-        mod = "Main.Junk"
-        path = junkpath
-        text = read(path, String)
-        function updatesymbols(mod, text, path)
-            parsed = CSTParser.parse(text, true)
-            items = Atom.toplevelitems(parsed, text)
-            Atom.updatesymbols(text, mod, path, items)
-        end
-
-        # check there is no cache before updating
-        @test filter(SYMBOLSCACHE[mod][path]) do item
-            Atom.str_value(item.expr) == "toplevelval2"
-        end |> isempty
-
-        # mock updatesymbol handler
-        originallines = readlines(path)
-        newtext = join(originallines[1:end - 1], '\n')
-        word = "toplevelval2"
-        newtext *= "\n$word = :youshoulderaseme\nend"
-        updatesymbols(mod, newtext, path)
-
-        # check the cache is updated
-        @test filter(SYMBOLSCACHE[mod][path]) do item
-            Atom.str_value(item.expr) == word
-        end |> !isempty
-
-        let items = toplevelgotoitems(word, mod, newtext, path) .|> Dict
+            items = Dict.(globalgotoitems("Main.Atom.handlers", "Atom", text, path))
             @test !isempty(items)
             @test items[1][:file] == path
-            @test items[1][:text] == "toplevelval2"
+            @test items[1][:text] == "handlers"
+
+            # can access the non-exported (non-method) bindings in the other module
+            path = joinpath′(@__DIR__, "..", "src", "goto.jl")
+            text = read(@__FILE__, String)
+            items = Dict.(globalgotoitems("Atom.SYMBOLSCACHE", "Main", text, @__FILE__))
+            @test !isempty(items)
+            @test items[1][:file] == path
+            @test items[1][:text] == "SYMBOLSCACHE"
         end
 
-        # re-update the cache
-        updatesymbols(mod, text, path)
-        @test filter(SYMBOLSCACHE[mod][path]) do item
-            Atom.str_value(item.expr) == word
-        end |> isempty
-    end
-
-    @testset "regenerating symbols" begin
-        regeneratesymbols()
-
-        @test haskey(SYMBOLSCACHE, "Base")
-        @test length(keys(SYMBOLSCACHE["Base"])) > 100
-        @test haskey(SYMBOLSCACHE, "Example") # cache symbols even if not loaded
-        @test toplevelgotoitems("hello", "Example", "", nothing) |> !isempty
-    end
-
-    @testset "goto methods" begin
-        ## basic
-        # `Atom.handlemsg` is not defined with default args
-        let items = methodgotoitems("Main", "Atom.handlemsg")
-            @test length(items) === length(methods(Atom.handlemsg))
+        @testset "goto modules" begin
+            let item = globalgotoitems("Atom", "Main", "", nothing)[1]
+                @test item.file == joinpath′(atomjldir, "Atom.jl")
+                @test item.line == 3
+            end
+            let item = globalgotoitems("Junk2", "Main.Junk", "", nothing)[1]
+                @test item.file == joinpath′(junkpath)
+                @test item.line == 14
+            end
         end
 
-        ## module awareness
-        let items = methodgotoitems("Atom", "handlemsg")
-            @test length(items) === length(methods(Atom.handlemsg))
+        @testset "goto toplevel symbols" begin
+            ## where Revise approach works, i.e.: precompiled modules
+            let path = joinpath′(atomjldir, "comm.jl")
+                text = read(path, String)
+                mod = Atom
+                key = "Atom"
+                word = "handlers"
+
+                # basic
+                let items = toplevelgotoitems(word, mod, text, path) .|> Dict
+                    @test !isempty(items)
+                    @test items[1][:file] == path
+                    @test items[1][:text] == word
+                end
+
+                # check caching works
+                @test haskey(SYMBOLSCACHE, key)
+
+                # check the Revise-like approach finds all files in Atom module
+                @test length(SYMBOLSCACHE[key]) == length(atommodfiles)
+
+                # when `path` isn't given, i.e. via docpane / workspace
+                let items = toplevelgotoitems(word, mod, "", nothing) .|> Dict
+                    @test !isempty(items)
+                    @test items[1][:file] == path
+                    @test items[1][:text] == word
+                end
+
+                # same as above, but without any previous cache -- falls back to CSTPraser-based module-walk
+                delete!(SYMBOLSCACHE, key)
+
+                let items = toplevelgotoitems(word, mod, "", nothing) .|> Dict
+                    @test !isempty(items)
+                    @test items[1][:file] == path
+                    @test items[1][:text] == word
+                end
+
+                # check CSTPraser-based module-walk finds all the included files
+                # currently broken:
+                # - files in submodules are included
+                # - webio.jl is excluded since `include("webio.jl")` is a toplevel call
+                @test_broken length(SYMBOLSCACHE[key]) == length(atommoddir)
+            end
+
+            ## where the Revise-like approach doesn't work, e.g. non-precompiled modules
+            let path = junkpath
+                text = read(path, String)
+                mod = Main.Junk
+                key = "Main.Junk"
+                word = "toplevelval"
+
+                # basic
+                let items = toplevelgotoitems(word, mod, text, path) .|> Dict
+                    @test !isempty(items)
+                    @test items[1][:file] == path
+                    @test items[1][:line] == 16
+                    @test items[1][:text] == word
+                end
+
+                # check caching works
+                @test haskey(Atom.SYMBOLSCACHE, key)
+
+                # when `path` isn't given, i.e.: via docpane / workspace
+                let items = toplevelgotoitems(word, mod, "", nothing) .|> Dict
+                    @test !isempty(items)
+                    @test items[1][:file] == path
+                    @test items[1][:line] == 16
+                    @test items[1][:text] == word
+                end
+            end
         end
 
-        ## aggregate methods with default params
-        @eval Main function funcwithdefaultargs(args, defarg = "default") end
+        @testset "updating toplevel symbols" begin
+            mod = "Main.Junk"
+            path = junkpath
+            text = read(path, String)
+            function updatesymbols(mod, text, path)
+                parsed = CSTParser.parse(text, true)
+                items = Atom.toplevelitems(parsed, text)
+                Atom.updatesymbols(text, mod, path, items)
+            end
 
-        let items = methodgotoitems("Main", "funcwithdefaultargs") .|> Dict
-            # should be handled as an unique method
-            @test length(items) === 1
-            # show a method with full arguments
-            @test "funcwithdefaultargs(args, defarg)" ∈ map(i -> i[:text], items)
+            # check there is no cache before updating
+            @test filter(SYMBOLSCACHE[mod][path]) do item
+                Atom.str_value(item.expr) == "toplevelval2"
+            end |> isempty
+
+            # mock updatesymbol handler
+            originallines = readlines(path)
+            newtext = join(originallines[1:end - 1], '\n')
+            word = "toplevelval2"
+            newtext *= "\n$word = :youshoulderaseme\nend"
+            updatesymbols(mod, newtext, path)
+
+            # check the cache is updated
+            @test filter(SYMBOLSCACHE[mod][path]) do item
+                Atom.str_value(item.expr) == word
+            end |> !isempty
+
+            let items = toplevelgotoitems(word, mod, newtext, path) .|> Dict
+                @test !isempty(items)
+                @test items[1][:file] == path
+                @test items[1][:text] == "toplevelval2"
+            end
+
+            # re-update the cache
+            updatesymbols(mod, text, path)
+            @test filter(SYMBOLSCACHE[mod][path]) do item
+                Atom.str_value(item.expr) == word
+            end |> isempty
         end
 
-        @eval Main function funcwithdefaultargs(args::String, defarg = "default") end
+        @testset "regenerating symbols" begin
+            regeneratesymbols()
 
-        let items = methodgotoitems("Main", "funcwithdefaultargs") .|> Dict
-            # should be handled as different methods
-            @test length(items) === 2
-            # show methods with full arguments
-            @test "funcwithdefaultargs(args, defarg)" ∈ map(i -> i[:text], items)
-            @test "funcwithdefaultargs(args::String, defarg)" ∈ map(i -> i[:text], items)
+            @test haskey(SYMBOLSCACHE, "Base")
+            @test length(keys(SYMBOLSCACHE["Base"])) > 100
+            @test haskey(SYMBOLSCACHE, "Example") # cache symbols even if not loaded
+            @test toplevelgotoitems("hello", "Example", "", nothing) |> !isempty
         end
-    end
 
-    # bundles `modulegotoitems`, `toplevelgotoitems` and `methodgotoitems`
-    @testset "goto global symbols" begin
-        # both the original methods and the toplevel bindings that are overloaded
-        # in a context module should be shown
+        @testset "goto methods" begin
+            ## basic
+            let ms = methods(Atom.handlemsg)
+                @test length(methodgotoitems(ms)) === length(ms)
+            end
+
+            ## aggregate methods with default params
+            @eval Main function funcwithdefaultargs(args, defarg = "default") end
+
+            let items = methodgotoitems(methods(funcwithdefaultargs)) .|> Dict
+                # should be handled as an unique method
+                @test length(items) === 1
+                # show a method with full arguments
+                @test "funcwithdefaultargs(args, defarg)" in map(i -> i[:text], items)
+            end
+
+            @eval Main function funcwithdefaultargs(args::String, defarg = "default") end
+
+            let items = methodgotoitems(methods(funcwithdefaultargs)) .|> Dict
+                # should be handled as different methods
+                @test length(items) === 2
+                # show methods with full arguments
+                @test "funcwithdefaultargs(args, defarg)" in map(i -> i[:text], items)
+                @test "funcwithdefaultargs(args::String, defarg)" in map(i -> i[:text], items)
+            end
+        end
+
+        ## both the original methods and the toplevel bindings that are overloaded in a context module should be shown
         let items = globalgotoitems("isconst", "Main.Junk", "", nothing)
             @test length(items) === 2
-            @test "isconst(m::Module, s::Symbol)" ∈ map(item -> item.text, items) # from Base
-            @test "Base.isconst(::JunkType)" ∈ map(item -> item.text, items) # from Junk
+            @test "isconst(m::Module, s::Symbol)" in map(item -> item.text, items) # from Base
+            @test "Base.isconst(::JunkType)" in map(item -> item.text, items) # from Junk
         end
+
+        ## don't error on the fallback case
+        @test globalgotoitems("word", "Main", "", nothing) == []
     end
 end

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -195,11 +195,7 @@
     end
 
     @testset "regenerating symbols" begin
-        # @info "––– caching symbols in loaded modules (only errors shown) ------"
-        # with_logger(ConsoleLogger(stderr, Base.CoreLogging.Warn)) do
         regeneratesymbols()
-        # end
-        # @info "––– finished caching -------------------------------------------"
 
         @test haskey(SYMBOLSCACHE, "Base")
         @test length(keys(SYMBOLSCACHE["Base"])) > 100
@@ -244,21 +240,10 @@
     @testset "goto global symbols" begin
         # both the original methods and the toplevel bindings that are overloaded
         # in a context module should be shown
-        let items = globalgotoitems("isconst", "isconst", "Main.Junk", "", nothing)
+        let items = globalgotoitems("isconst", "Main.Junk", "", nothing)
             @test length(items) === 2
             @test "isconst(m::Module, s::Symbol)" ∈ map(item -> item.text, items) # from Base
             @test "Base.isconst(::JunkType)" ∈ map(item -> item.text, items) # from Junk
-        end
-
-        # strips trailing dots
-        let item = globalgotoitems("isconst", "isconst", "Main.Junk", "", nothing)
-            @test item == globalgotoitems("isconst", "Junk.isconst", "Main.Junk", "", nothing)
-            @test item == globalgotoitems("isconst", "Main.Junk.isconst", "Main.Junk", "", nothing)
-        end
-        let item = globalgotoitems("Junk", "Junk", "Main.Junk", "", nothing)
-            @test item == globalgotoitems("Junk", "Main.Junk", "Main.Junk", "", nothing)
-            @test item == globalgotoitems("Junk", "Junk.isconst", "Main.Junk", "", nothing)
-            @test item == globalgotoitems("Junk", "Main.Junk.isconst", "Main.Junk", "", nothing)
         end
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -114,3 +114,18 @@ end
         @test strlimit("Jμλια in the Nutshell", 20, " ...") == "Jμλια in the Nut ..."
     end
 end
+
+@testset "strip trailing dots" begin
+    using Atom: striptrailingdots
+
+    # only including ASCII
+    @test striptrailingdots("field", "Head.field") == "Head.field"
+    @test striptrailingdots("Head", "Head.field") == "Head"
+
+    # including Unicode
+    @test striptrailingdots("fιηλδ", "Hηαδ.fιηλδ") == "Hηαδ.fιηλδ"
+    @test striptrailingdots("Hηαδ", "Hηαδ.fιηλδ") == "Hηαδ"
+
+    # invalid case
+    @test_nowarn striptrailingdots("foo", "head.field")
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -114,18 +114,3 @@ end
         @test strlimit("Jμλια in the Nutshell", 20, " ...") == "Jμλια in the Nut ..."
     end
 end
-
-@testset "strip trailing dots" begin
-    using Atom: striptrailingdots
-
-    # only including ASCII
-    @test striptrailingdots("field", "Head.field") == "Head.field"
-    @test striptrailingdots("Head", "Head.field") == "Head"
-
-    # including Unicode
-    @test striptrailingdots("fιηλδ", "Hηαδ.fιηλδ") == "Hηαδ.fιηλδ"
-    @test striptrailingdots("Hηαδ", "Hηαδ.fιηλδ") == "Hηαδ"
-
-    # invalid case
-    @test_nowarn striptrailingdots("foo", "head.field")
-end


### PR DESCRIPTION
While implementing #203, I had to implement the logic to remove trailing dots and found that this is better to be merged as a separate feature, since the logic can be used for goto/datatip.

In short, if we have a word like
```jl
Atom.SYMBOLSCACHE.age
```
and then, we can get goto and datatip for:
- `Atom` when our cursor is anywhere on `Atom`
- `Atom.SYMBOLSCACHE` when our cursor is anywhere on `SYMBOLSCACHE`
- no datatip if our cursor is on `age` (the field)

(c.f.: The current behaviour: we can't get any goto and datatip at all)

***

Requires https://github.com/JunoLab/atom-julia-client/pull/651