### PR TITLE
RFC: module validation check within CSTParser-based module traverse

### DIFF
--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -22,12 +22,12 @@ function __init__()
 
       # HACK: overloading this allows us to open remote files
       InteractiveUtils.eval(quote
-        function InteractiveUtils.edit(path::AbstractString, line::Integer=0)
+        function InteractiveUtils.edit(path::AbstractString, line::Integer = 0)
           if endswith(path, ".jl")
-              f = Base.find_source_file(path)
-              f !== nothing && (path = f)
+            f = Base.find_source_file(path)
+            f !== nothing && (path = f)
           end
-          $(msg)("openFile", Base.abspath(path), line-1)
+          $(msg)("openFile", Base.abspath(path), line - 1)
         end
       end)
     end

--- a/src/goto.jl
+++ b/src/goto.jl
@@ -194,8 +194,7 @@ function _collecttoplevelitems!(mod::Union{Nothing, String}, entrypath::String, 
   _collecttoplevelitems!(mod, entrypath, text, pathitemsmaps)
 end
 function _collecttoplevelitems!(mod::Union{Nothing, String}, entrypath::String, text::String, pathitemsmaps::PathItemsMaps)
-  parsed = CSTParser.parse(text, true)
-  items = toplevelitems(parsed, text; mod = mod)
+  items = toplevelitems(text; mod = mod)
   push!(pathitemsmaps, entrypath => items)
 
   # looking for toplevel `include` calls

--- a/src/goto.jl
+++ b/src/goto.jl
@@ -1,5 +1,3 @@
-using CSTParser
-
 handle("gotosymbol") do data
   @destruct [
     word,
@@ -144,8 +142,8 @@ function collecttoplevelitems(mod::String, path::String, text::String)
   pathitemsmaps = PathItemsMaps()
   return if mod == "Main" || isuntitled(path)
     # for `Main` module and unsaved editors, always use CSTPraser-based approach
-    # with a given buffer text
-    _collecttoplevelitems!(mod, path, text, pathitemsmaps)
+    # with a given buffer text, and don't check module validity
+    _collecttoplevelitems!(nothing, path, text, pathitemsmaps)
   else
     _collecttoplevelitems!(mod, pathitemsmaps)
   end
@@ -182,12 +180,12 @@ function _collecttoplevelitems!(paths::Vector{String}, pathitemsmaps::PathItemsM
 end
 
 # module-walk based on CSTParser, looking for toplevel `installed` calls
-function _collecttoplevelitems!(mod::String, entrypath::String, pathitemsmaps::PathItemsMaps)
+function _collecttoplevelitems!(mod::Union{Nothing, String}, entrypath::String, pathitemsmaps::PathItemsMaps)
   isfile′(entrypath) || return
   text = read(entrypath, String)
   _collecttoplevelitems!(mod, entrypath, text, pathitemsmaps)
 end
-function _collecttoplevelitems!(mod::String, entrypath::String, text::String, pathitemsmaps::PathItemsMaps)
+function _collecttoplevelitems!(mod::Union{Nothing, String}, entrypath::String, text::String, pathitemsmaps::PathItemsMaps)
   parsed = CSTParser.parse(text, true)
   items = toplevelitems(parsed, text; mod = mod)
   push!(pathitemsmaps, entrypath => items)

--- a/src/goto.jl
+++ b/src/goto.jl
@@ -168,7 +168,8 @@ end
 function _collecttoplevelitems!(mod::Module, pathitemsmaps::PathItemsMaps)
   entrypath, paths = modulefiles(mod)
   return if entrypath !== nothing # Revise-like approach
-    _collecttoplevelitems!([entrypath; paths], pathitemsmaps)
+    mod = string(last(split(string(mod), '.'))) # strip parent module prefixes e.g.: `"Main.Junk"`
+    _collecttoplevelitems!(mod, [entrypath; paths], pathitemsmaps)
   else # if Revise-like approach fails, fallback to CSTParser-based approach
     entrypath, line = moduledefinition(mod)
     mod = string(last(split(string(mod), '.'))) # strip parent module prefixes e.g.: `"Main.Junk"`
@@ -177,11 +178,10 @@ function _collecttoplevelitems!(mod::Module, pathitemsmaps::PathItemsMaps)
 end
 
 # module-walk via Revise-like approach
-function _collecttoplevelitems!(paths::Vector{String}, pathitemsmaps::PathItemsMaps)
+function _collecttoplevelitems!(mod::Union{Nothing, String}, paths::Vector{String}, pathitemsmaps::PathItemsMaps)
   for path in paths
     text = read(path, String)
-    parsed = CSTParser.parse(text, true)
-    items = toplevelitems(parsed, text)
+    items = toplevelitems(text; mod = mod)
     push!(pathitemsmaps, path => items)
   end
   pathitemsmaps

--- a/src/modules.jl
+++ b/src/modules.jl
@@ -113,7 +113,7 @@ const stdlib_names = Set([
 
 function pkg_fileinfo(id::PkgId)
   uuid, name = id.uuid, id.name
-    # Try to find the matching cache file
+  # Try to find the matching cache file
   paths = Base.find_all_in_cache_path(id)
   sourcepath = Base.locate_package(id)
   for path in paths
@@ -141,8 +141,8 @@ function parse_cache_header(f::IO)
     push!(modules, PkgId(uuid, sym) => build_id)
   end
   totbytes = read(f, Int64) # total bytes for file dependencies
-    # read the list of requirements
-    # and split the list into include and requires statements
+  # read the list of requirements
+  # and split the list into include and requires statements
   includes = Tuple{Module,String,Float64}[]
   requires = Pair{Module,PkgId}[]
   while true
@@ -153,7 +153,7 @@ function parse_cache_header(f::IO)
     n1 = read(f, Int32)
     mod = (n1 == 0) ? Main : Base.root_module(modules[n1].first)
     if n1 != 0
-            # determine the complete module path
+      # determine the complete module path
       while true
         n1 = read(f, Int32)
         totbytes -= 4
@@ -186,20 +186,21 @@ end
 # ------------------------
 
 """
-    included_files = modulefiles(entrypath::String)::Vector{String}
+    included_files = modulefiles(mod::String, entrypath::String)::Vector{String}
 
-Returns all the files that can be reached via [`include`](@ref) calls from `entrypath`.
-Note this function currently only looks for static toplevel calls (i.e. miss the calls
-  in not in toplevel scope), and can include files in the submodules as well.
+Returns all the files in `mod` module that can be reached via [`include`](@ref)
+  calls from `entrypath`.
+Note this function currently only looks for static toplevel calls (i.e. miss the
+  calls in non-toplevel scope).
 """
-function modulefiles(entrypath::String, files = Vector{String}())
+function modulefiles(mod::String, entrypath::String, files = Vector{String}())
   isfile′(entrypath) || return files
 
   push!(files, entrypath)
 
   text = read(entrypath, String)
   parsed = CSTParser.parse(text, true)
-  items = toplevelitems(parsed, text)
+  items = toplevelitems(parsed, text; mod = mod)
 
   for item in items
     if item isa ToplevelCall
@@ -208,7 +209,7 @@ function modulefiles(entrypath::String, files = Vector{String}())
         nextfile = expr.args[3].val
         nextentrypath = joinpath(dirname(entrypath), nextfile)
         isfile(nextentrypath) || continue
-        modulefiles(nextentrypath, files)
+        modulefiles(mod, nextentrypath, files)
       end
     end
   end

--- a/src/modules.jl
+++ b/src/modules.jl
@@ -199,8 +199,7 @@ function modulefiles(mod::String, entrypath::String, files = Vector{String}())
   push!(files, entrypath)
 
   text = read(entrypath, String)
-  parsed = CSTParser.parse(text, true)
-  items = toplevelitems(parsed, text; mod = mod)
+  items = toplevelitems(text; mod = mod)
 
   for item in items
     if item isa ToplevelCall

--- a/src/modules.jl
+++ b/src/modules.jl
@@ -193,13 +193,13 @@ Returns all the files in `mod` module that can be reached via [`include`](@ref)
 Note this function currently only looks for static toplevel calls (i.e. miss the
   calls in non-toplevel scope).
 """
-function modulefiles(mod::String, entrypath::String, files = Vector{String}())
+function modulefiles(mod::String, entrypath::String, files = Vector{String}(); inmod = false)
   isfile′(entrypath) || return files
 
   push!(files, entrypath)
 
   text = read(entrypath, String)
-  items = toplevelitems(text; mod = mod)
+  items = toplevelitems(text; mod = mod, inmod = inmod)
 
   for item in items
     if item isa ToplevelCall
@@ -208,7 +208,8 @@ function modulefiles(mod::String, entrypath::String, files = Vector{String}())
         nextfile = expr.args[3].val
         nextentrypath = joinpath(dirname(entrypath), nextfile)
         isfile(nextentrypath) || continue
-        modulefiles(mod, nextentrypath, files)
+        # `nextentrypath` is always in `mod`
+        modulefiles(mod, nextentrypath, files; inmod = true)
       end
     end
   end

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -2,7 +2,7 @@ handle("updateeditor") do data
     @destruct [
         text || "",
         mod || "Main",
-        path || "untitled",
+        path || nothing,
         updateSymbols || true
     ] = data
 
@@ -14,13 +14,13 @@ handle("updateeditor") do data
 end
 
 # NOTE: update outline and symbols cache all in one go
-function updateeditor(text, mod = "Main", path = "untitled", updateSymbols = true)
+function updateeditor(text, mod = "Main", path = nothing, updateSymbols = true)
     parsed = CSTParser.parse(text, true)
     items = toplevelitems(parsed, text)
 
     # update symbols cache
     # ref: https://github.com/JunoLab/Juno.jl/issues/407
-    updateSymbols && updatesymbols(text, mod, path, items)
+    updateSymbols && updatesymbols(items, mod, path, text)
 
     # return outline
     outline(items)

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -15,8 +15,7 @@ end
 
 # NOTE: update outline and symbols cache all in one go
 function updateeditor(text, mod = "Main", path = nothing, updateSymbols = true)
-    parsed = CSTParser.parse(text, true)
-    items = toplevelitems(parsed, text)
+    items = toplevelitems(text)
 
     # update symbols cache
     # ref: https://github.com/JunoLab/Juno.jl/issues/407

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -15,14 +15,12 @@ end
 
 # NOTE: update outline and symbols cache all in one go
 function updateeditor(text, mod = "Main", path = nothing, updateSymbols = true)
-    items = toplevelitems(text)
-
     # update symbols cache
     # ref: https://github.com/JunoLab/Juno.jl/issues/407
-    updateSymbols && updatesymbols(items, mod, path, text)
+    updateSymbols && updatesymbols(mod, path, text)
 
     # return outline
-    outline(items)
+    outline(toplevelitems(text))
 end
 
 function outline(items)

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -50,6 +50,9 @@ function isinclude(expr::CSTParser.EXPR)
         endswith(expr.args[3].val, ".jl")
 end
 
+ismodule(expr::CSTParser.EXPR) =
+    expr.typ === CSTParser.ModuleH || expr.typ === CSTParser.BareModule
+
 function isdoc(expr::CSTParser.EXPR)
     expr.typ === CSTParser.MacroCall &&
         length(expr.args) >= 1 &&

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -146,6 +146,9 @@ end
 
 shortstr(val) = strlimit(string(val), 20)
 
+"""used to strip parent module prefixes e.g.: `"Main.Junk" ⟶ "Junk"`"""
+stripdotprefixes(str::AbstractString)  = string(last(split(str, '.')))
+
 """
     Undefined
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -17,7 +17,14 @@ nonwritablefiles(files) = filter(!iswritablefile, files)
 
 include("path_matching.jl")
 
-isuntitled(p) = occursin(r"^(\.\\|\./)?untitled-[\d\w]+(:\d+)?$", p)
+"""
+    isuntitled(path::AbstractString)
+
+Checks if `path` represents an unsaved editor.
+Usualy the string that follows `"untitled-"` is obtained from `editor.getBuffer().getId()`:
+  e.g. `path = "untitled-266305858c1298b906bed15ddad81cea"`.
+"""
+isuntitled(path::AbstractString) = occursin(r"^(\.\\|\./)?untitled-[\d\w]+(:\d+)?$", path)
 
 appendline(path, line) = line > 0 ? "$path:$line" : path
 

--- a/test/completions.jl
+++ b/test/completions.jl
@@ -163,5 +163,5 @@ end
     end
 
     # don't error on fallback case
-    @test Atom.localcompletions("", 1, 1) == []
+    @test_nowarn @test Atom.localcompletions("", 1, 1) == []
 end

--- a/test/datatip.jl
+++ b/test/datatip.jl
@@ -34,7 +34,7 @@
         end
 
         # don't error on fallback case
-        @test Atom.localdatatip("word", 1, 1, 0, "") == []
+        @test_nowarn @test Atom.localdatatip("word", 1, 1, 0, "") == []
     end
 
     @testset "code block search" begin

--- a/test/fixtures/Junk.jl
+++ b/test/fixtures/Junk.jl
@@ -12,22 +12,12 @@ macro immacro(expr)
     end
 end
 
-module Junk2 end
-
 const toplevelval = "you should jump to me !"
 
 # mock overloaded method
 struct JunkType end
 Base.isconst(::JunkType) = false
 
-"""im a doc in Junk"""
-const imwithdoc = nothing
-
-baremodule BareJunk
-
-"""im a doc in BareJunk"""
-const imwithdoc = nothing
-
-end
+include("SubJunks.jl")
 
 end

--- a/test/fixtures/SubJunks.jl
+++ b/test/fixtures/SubJunks.jl
@@ -1,0 +1,16 @@
+"""im a doc in Junk"""
+const imwithdoc = nothing
+
+module SubJunk
+
+"""im a doc in SubJunk"""
+const imwithdoc = nothing
+
+end
+
+baremodule BareJunk
+
+"""im a doc in BareJunk"""
+const imwithdoc = nothing
+
+end

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -1,4 +1,6 @@
 @testset "goto symbols" begin
+    using Atom: todict
+
     @testset "goto local symbols" begin
         let str = """
             function localgotoitem(word, path, column, row, startRow, context) # L0
@@ -15,7 +17,7 @@
               end                                                              # L11
             end                                                                # L12
             """,
-            localgotoitem(word, line) = Atom.localgotoitem(word, "path", Inf, line + 1, 0, str)[1] |> Dict
+            localgotoitem(word, line) = Atom.localgotoitem(word, "path", Inf, line + 1, 0, str)[1] |> todict
 
             let item = localgotoitem("row", 2)
                 @test item[:line] === 0
@@ -35,7 +37,7 @@
                 return val
             end
             """,
-            localgotoitem(word, line) = Atom.localgotoitem(word, "path", Inf, line + 1, 0, str)[1] |> Dict
+            localgotoitem(word, line) = Atom.localgotoitem(word, "path", Inf, line + 1, 0, str)[1] |> todict
 
             @test localgotoitem("expr.args", 1)[:line] === 0
             @test localgotoitem("bind.val", 2)[:line] === 1
@@ -47,17 +49,17 @@
 
     @testset "goto global symbols" begin
         using Atom: globalgotoitems, toplevelgotoitems, SYMBOLSCACHE,
-                    regeneratesymbols, methodgotoitems
+                    clearsymbols, regeneratesymbols, methodgotoitems
 
         ## strip a dot-accessed modules
         let
             path = joinpath′(@__DIR__, "..", "src", "comm.jl")
             text = read(path, String)
-            items = Dict.(globalgotoitems("Atom.handlers", "Atom", text, path))
+            items = todict.(globalgotoitems("Atom.handlers", "Atom", path, text))
             @test !isempty(items)
             @test items[1][:file] == path
             @test items[1][:text] == "handlers"
-            items = Dict.(globalgotoitems("Main.Atom.handlers", "Atom", text, path))
+            items = todict.(globalgotoitems("Main.Atom.handlers", "Atom", path, text))
             @test !isempty(items)
             @test items[1][:file] == path
             @test items[1][:text] == "handlers"
@@ -65,20 +67,20 @@
             # can access the non-exported (non-method) bindings in the other module
             path = joinpath′(@__DIR__, "..", "src", "goto.jl")
             text = read(@__FILE__, String)
-            items = Dict.(globalgotoitems("Atom.SYMBOLSCACHE", "Main", text, @__FILE__))
+            items = todict.(globalgotoitems("Atom.SYMBOLSCACHE", "Main", @__FILE__, text))
             @test !isempty(items)
             @test items[1][:file] == path
             @test items[1][:text] == "SYMBOLSCACHE"
         end
 
         @testset "goto modules" begin
-            let item = globalgotoitems("Atom", "Main", "", nothing)[1]
-                @test item.file == joinpath′(atomjldir, "Atom.jl")
-                @test item.line == 3
+            let item = globalgotoitems("Atom", "Main", nothing, "")[1] |> todict
+                @test item[:file] == joinpath′(atomjldir, "Atom.jl")
+                @test item[:line] == 3
             end
-            let item = globalgotoitems("Junk2", "Main.Junk", "", nothing)[1]
-                @test item.file == joinpath′(junkpath)
-                @test item.line == 14
+            let item = globalgotoitems("Junk2", "Main.Junk", nothing, "")[1] |> todict
+                @test item[:file] == joinpath′(junkpath)
+                @test item[:line] == 14
             end
         end
 
@@ -86,55 +88,51 @@
             ## where Revise approach works, i.e.: precompiled modules
             let path = joinpath′(atomjldir, "comm.jl")
                 text = read(path, String)
-                mod = Atom
-                key = "Atom"
+                mod = "Atom"
                 word = "handlers"
 
                 # basic
-                let items = toplevelgotoitems(word, mod, text, path) .|> Dict
+                let items = todict.(toplevelgotoitems(word, mod, path, text))
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:text] == word
                 end
 
                 # check caching works
-                @test haskey(SYMBOLSCACHE, key)
+                @test haskey(SYMBOLSCACHE, mod)
 
                 # check the Revise-like approach finds all files in Atom module
-                @test length(SYMBOLSCACHE[key]) == length(atommodfiles)
+                @test length(SYMBOLSCACHE[mod]) == length(atommodfiles)
 
                 # when `path` isn't given, i.e. via docpane / workspace
-                let items = toplevelgotoitems(word, mod, "", nothing) .|> Dict
+                let items = todict.(toplevelgotoitems(word, mod, nothing, ""))
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:text] == word
                 end
 
                 # same as above, but without any previous cache -- falls back to CSTPraser-based module-walk
-                delete!(SYMBOLSCACHE, key)
+                delete!(SYMBOLSCACHE, mod)
 
-                let items = toplevelgotoitems(word, mod, "", nothing) .|> Dict
+                let items = toplevelgotoitems(word, mod, nothing, "") .|> todict
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:text] == word
                 end
 
                 # check CSTPraser-based module-walk finds all the included files
-                # currently broken:
-                # - files in submodules are included
-                # - webio.jl is excluded since `include("webio.jl")` is a toplevel call
-                @test_broken length(SYMBOLSCACHE[key]) == length(atommoddir)
+                # NOTE: webio.jl is excluded since `include("webio.jl")` is a toplevel call
+                @test length(SYMBOLSCACHE[mod]) == length(atommodfiles)
             end
 
             ## where the Revise-like approach doesn't work, e.g. non-precompiled modules
             let path = junkpath
                 text = read(path, String)
-                mod = Main.Junk
-                key = "Main.Junk"
+                mod = "Main.Junk"
                 word = "toplevelval"
 
                 # basic
-                let items = toplevelgotoitems(word, mod, text, path) .|> Dict
+                let items = toplevelgotoitems(word, mod, path, text) .|> todict
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:line] == 16
@@ -142,10 +140,10 @@
                 end
 
                 # check caching works
-                @test haskey(Atom.SYMBOLSCACHE, key)
+                @test haskey(Atom.SYMBOLSCACHE, mod)
 
                 # when `path` isn't given, i.e.: via docpane / workspace
-                let items = toplevelgotoitems(word, mod, "", nothing) .|> Dict
+                let items = toplevelgotoitems(word, mod, nothing, "") .|> todict
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:line] == 16
@@ -155,16 +153,16 @@
         end
 
         @testset "updating toplevel symbols" begin
-            mod = "Main.Junk"
-            path = junkpath
-            text = read(path, String)
-            function updatesymbols(mod, text, path)
+            function updatesymbols(mod, path, text)
                 parsed = CSTParser.parse(text, true)
                 items = Atom.toplevelitems(parsed, text)
-                Atom.updatesymbols(text, mod, path, items)
+                Atom.updatesymbols(items, mod, path, text)
             end
 
             # check there is no cache before updating
+            mod = "Main.Junk"
+            path = junkpath
+            text = read(path, String)
             @test filter(SYMBOLSCACHE[mod][path]) do item
                 Atom.str_value(item.expr) == "toplevelval2"
             end |> isempty
@@ -174,33 +172,39 @@
             newtext = join(originallines[1:end - 1], '\n')
             word = "toplevelval2"
             newtext *= "\n$word = :youshoulderaseme\nend"
-            updatesymbols(mod, newtext, path)
+            updatesymbols(mod, path, newtext)
 
             # check the cache is updated
             @test filter(SYMBOLSCACHE[mod][path]) do item
                 Atom.str_value(item.expr) == word
             end |> !isempty
 
-            let items = toplevelgotoitems(word, mod, newtext, path) .|> Dict
+            let items = toplevelgotoitems(word, mod, path, newtext) .|> todict
                 @test !isempty(items)
                 @test items[1][:file] == path
                 @test items[1][:text] == "toplevelval2"
             end
 
             # re-update the cache
-            updatesymbols(mod, text, path)
+            updatesymbols(mod, path, text)
             @test filter(SYMBOLSCACHE[mod][path]) do item
                 Atom.str_value(item.expr) == word
             end |> isempty
         end
 
-        @testset "regenerating symbols" begin
+        @testset "regenerating toplevel symbols" begin
             regeneratesymbols()
 
             @test haskey(SYMBOLSCACHE, "Base")
             @test length(keys(SYMBOLSCACHE["Base"])) > 100
             @test haskey(SYMBOLSCACHE, "Example") # cache symbols even if not loaded
             @test toplevelgotoitems("hello", "Example", "", nothing) |> !isempty
+        end
+
+        @testset "clear toplevel symbols" begin
+            clearsymbols()
+
+            @test length(keys(SYMBOLSCACHE)) === 0
         end
 
         @testset "goto methods" begin
@@ -212,7 +216,7 @@
             ## aggregate methods with default params
             @eval Main function funcwithdefaultargs(args, defarg = "default") end
 
-            let items = methodgotoitems(methods(funcwithdefaultargs)) .|> Dict
+            let items = methodgotoitems(methods(funcwithdefaultargs)) .|> todict
                 # should be handled as an unique method
                 @test length(items) === 1
                 # show a method with full arguments
@@ -221,7 +225,7 @@
 
             @eval Main function funcwithdefaultargs(args::String, defarg = "default") end
 
-            let items = methodgotoitems(methods(funcwithdefaultargs)) .|> Dict
+            let items = methodgotoitems(methods(funcwithdefaultargs)) .|> todict
                 # should be handled as different methods
                 @test length(items) === 2
                 # show methods with full arguments
@@ -231,13 +235,13 @@
         end
 
         ## both the original methods and the toplevel bindings that are overloaded in a context module should be shown
-        let items = globalgotoitems("isconst", "Main.Junk", "", nothing)
+        let items = globalgotoitems("isconst", "Main.Junk", nothing, "")
             @test length(items) === 2
             @test "isconst(m::Module, s::Symbol)" in map(item -> item.text, items) # from Base
             @test "Base.isconst(::JunkType)" in map(item -> item.text, items) # from Junk
         end
 
         ## don't error on the fallback case
-        @test globalgotoitems("word", "Main", "", nothing) == []
+        @test globalgotoitems("word", "Main", nothing, "") == []
     end
 end

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -44,7 +44,7 @@
         end
 
         # don't error on fallback case
-        @test Atom.localgotoitem("word", nothing, 1, 1, 0, "") == []
+        @test_nowarn @test Atom.localgotoitem("word", nothing, 1, 1, 0, "") == []
     end
 
     @testset "goto global symbols" begin
@@ -216,6 +216,9 @@
             @test filter(SYMBOLSCACHE[mod][path]) do item
                 Atom.str_value(item.expr) == word
             end |> isempty
+
+            # don't error on fallback case
+            @test_nowarn @test updatesymbols(mod, nothing, text) === nothing
         end
 
         @testset "regenerating toplevel symbols" begin
@@ -268,6 +271,6 @@
         end
 
         ## don't error on the fallback case
-        @test globalgotoitems("word", "Main", nothing, "") == []
+        @test_nowarn @test globalgotoitems("word", "Main", nothing, "") == []
     end
 end

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -182,8 +182,7 @@
 
         @testset "updating toplevel symbols" begin
             function updatesymbols(mod, path, text)
-                parsed = CSTParser.parse(text, true)
-                items = Atom.toplevelitems(parsed, text)
+                items = Atom.toplevelitems(text)
                 Atom.updatesymbols(items, mod, path, text)
             end
 

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -150,6 +150,19 @@
                     @test items[1][:text] == word
                 end
             end
+
+            ## `Main` module -- use a passed buffer text
+            let path = joinpath′(@__DIR__, "runtests.jl")
+                text = read(path, String)
+                mod = "Main"
+                word = "atomjldir"
+
+                items = toplevelgotoitems(word, mod, path, text) .|> todict
+                @test !isempty(items)
+                @test items[1][:file] == path
+                @test items[1][:line] == 5
+                @test items[1][:text] == word
+            end
         end
 
         @testset "updating toplevel symbols" begin

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -48,7 +48,7 @@
     end
 
     @testset "goto global symbols" begin
-        using Atom: globalgotoitems, toplevelgotoitems, SYMBOLSCACHE,
+        using Atom: globalgotoitems, toplevelgotoitems, SYMBOLSCACHE, updatesymbols,
                     clearsymbols, regeneratesymbols, methodgotoitems
 
         ## strip a dot-accessed modules
@@ -158,7 +158,7 @@
                 word = "imwithdoc"
 
                 items = toplevelgotoitems(word, mod, path, text) .|> todict
-                @test_broken length(items) === 1 # broken since it finds `imwithdoc` in `Junk` as well
+                @test length(items) === 1
                 if length(items) === 1
                     @test items[1][:file] == path
                     @test items[1][:line] == 6
@@ -181,11 +181,6 @@
         end
 
         @testset "updating toplevel symbols" begin
-            function updatesymbols(mod, path, text)
-                items = Atom.toplevelitems(text)
-                Atom.updatesymbols(items, mod, path, text)
-            end
-
             # check there is no cache before updating
             mod = Main.Junk
             key = "Main.Junk"

--- a/test/modules.jl
+++ b/test/modules.jl
@@ -3,16 +3,16 @@
         using Atom: moduledefinition
 
         let (path, line) = moduledefinition(Atom)
-            @test path == joinpath′(@__DIR__, "..", "src", "Atom.jl")
+            @test path == atommodfile
             @test line == 4
         end
         let (path, line) = moduledefinition(Junk)
-            @test path == joinpath′(@__DIR__, "fixtures", "Junk.jl")
+            @test path == junkpath
             @test line == 1
         end
-        let (path, line) = moduledefinition(Junk.Junk2)
-            @test path == joinpath′(@__DIR__, "fixtures", "Junk.jl")
-            @test line == 15
+        let (path, line) = moduledefinition(Junk.SubJunk)
+            @test path == subjunkspath
+            @test line == 4
         end
     end
 
@@ -34,7 +34,7 @@
         @test_broken junkpath == modulefiles(Junk)[1]
 
         ## CSTPraser-based module file detection
-        let included_files = normpath.(modulefiles("Atom", joinpath′(atomjldir, "Atom.jl")))
+        let included_files = normpath.(modulefiles("Atom", atommodfile))
             # finds all the files in Atom module except display/webio.jl
             for f in atommodfiles
                 f == webiofile && continue

--- a/test/modules.jl
+++ b/test/modules.jl
@@ -34,15 +34,15 @@
         @test_broken junkpath == modulefiles(Junk)[1]
 
         ## CSTPraser-based module file detection
-        let included_files = normpath.(modulefiles(joinpath′(atomjldir, "Atom.jl")))
+        let included_files = normpath.(modulefiles("Atom", joinpath′(atomjldir, "Atom.jl")))
             # finds all the files in Atom module except display/webio.jl
             for f in atommodfiles
                 f == webiofile && continue
                 @test f in included_files
             end
 
-            # can't exclude files in the submodules
-            @test_broken length(atommodfiles) == length(included_files)
+            # only finds files in a module -- exclude files in the submodules
+            @test length(atommodfiles) == length(included_files)
 
             # can't look for non-toplevel `include` calls
             @test_broken webiofile in included_files

--- a/test/outline.jl
+++ b/test/outline.jl
@@ -1,9 +1,5 @@
 @testset "outline" begin
-    function outline(str)
-        parsed = CSTParser.parse(str, true)
-        items = Atom.toplevelitems(parsed, str)
-        Atom.outline(items)
-    end
+    outline(text) = Atom.outline(Atom.toplevelitems(text))
 
     let str = """
         module Foo

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Atom, Test, JSON, Logging, CSTParser
+using Atom, Test, JSON, Logging, CSTParser, Example
 
 
 joinpath′(files...) = Atom.fullpath(joinpath(files...))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Atom, Test, JSON, Logging, CSTParser
 joinpath′(files...) = Atom.fullpath(joinpath(files...))
 
 atomjldir = joinpath′(@__DIR__, "..", "src")
-
+atommodfile = joinpath′(atomjldir, "Atom.jl")
 webiofile = joinpath′(atomjldir, "display", "webio.jl")
 
 # files in `Atom` module (except files in its submodules)
@@ -42,6 +42,7 @@ readmsg() = JSON.parse(String(take!(Atom.sock)))
 
 # mock Module
 junkpath = joinpath′(@__DIR__, "fixtures", "Junk.jl")
+subjunkspath = joinpath′(@__DIR__, "fixtures", "SubJunks.jl")
 include(junkpath)
 
 # basics

--- a/test/static/static.jl
+++ b/test/static/static.jl
@@ -1,8 +1,7 @@
 @testset "static analysis" begin
-    # TODO
-    # @testset "toplevel items" begin
-    #     include("toplevel.jl")
-    # end
+    @testset "toplevel items" begin
+        include("toplevel.jl")
+    end
 
     @testset "local bindings" begin
         include("local.jl")

--- a/test/static/toplevel.jl
+++ b/test/static/toplevel.jl
@@ -3,23 +3,21 @@
 
     path = subjunkspath
     text = read(path, String)
-    parsed = CSTParser.parse(text, true)
 
-    # basic -- finds every toplevel items when `mod` options is `nothing` (default)
-    @test filter(toplevelitems(text; mod = nothing)) do item
+    # basic -- finds every toplevel items with default arguments
+    @test filter(toplevelitems(text)) do item
         item isa Atom.ToplevelBinding &&
         item.bind.name == "imwithdoc"
     end |> length === 3
 
     # don't enter non-target modules, e.g.: submodules
-    @test filter(toplevelitems(text; mod = "Junk")) do item
+    @test filter(toplevelitems(text; mod = "Junk", inmod = true)) do item
         item isa Atom.ToplevelBinding &&
         item.bind.name == "imwithdoc"
     end |> length === 1 # should only find the `imwithdoc` in Junk module
 
     # don't include items outside of a module
-    # FIX: currently broken -- include `imwithdoc` in Junk module as well
-    @test_broken filter(toplevelitems(text; mod = "SubJunk")) do item
+    @test filter(toplevelitems(text; mod = "SubJunk", inmod = false)) do item
         item isa Atom.ToplevelBinding &&
         item.bind.name == "imwithdoc"
     end |> length === 1 # should only find the `imwithdoc` in SubJunk module

--- a/test/static/toplevel.jl
+++ b/test/static/toplevel.jl
@@ -1,0 +1,26 @@
+@testset "module validation" begin
+    using Atom: toplevelitems
+
+    path = subjunkspath
+    text = read(path, String)
+    parsed = CSTParser.parse(text, true)
+
+    # basic -- finds every toplevel items when `mod` options is `nothing` (default)
+    @test filter(toplevelitems(parsed, text; mod = nothing)) do item
+        item isa Atom.ToplevelBinding &&
+        item.bind.name == "imwithdoc"
+    end |> length === 3
+
+    # don't enter non-target modules, e.g.: submodules
+    @test filter(toplevelitems(parsed, text; mod = "Junk")) do item
+        item isa Atom.ToplevelBinding &&
+        item.bind.name == "imwithdoc"
+    end |> length === 1 # only `imwithdoc` in Junk module
+
+    # don't include items outside of a module
+    # FIX: currently broken -- include `imwithdoc` in Junk module as well
+    @test_broken filter(toplevelitems(parsed, text; mod = "SubJunk")) do item
+        item isa Atom.ToplevelBinding &&
+        item.bind.name == "imwithdoc"
+    end |> length === 1 # only `imwithdoc` in Junk module
+end

--- a/test/static/toplevel.jl
+++ b/test/static/toplevel.jl
@@ -15,12 +15,12 @@
     @test filter(toplevelitems(parsed, text; mod = "Junk")) do item
         item isa Atom.ToplevelBinding &&
         item.bind.name == "imwithdoc"
-    end |> length === 1 # only `imwithdoc` in Junk module
+    end |> length === 1 # should only find the `imwithdoc` in Junk module
 
     # don't include items outside of a module
     # FIX: currently broken -- include `imwithdoc` in Junk module as well
     @test_broken filter(toplevelitems(parsed, text; mod = "SubJunk")) do item
         item isa Atom.ToplevelBinding &&
         item.bind.name == "imwithdoc"
-    end |> length === 1 # only `imwithdoc` in Junk module
+    end |> length === 1 # should only find the `imwithdoc` in SubJunk module
 end

--- a/test/static/toplevel.jl
+++ b/test/static/toplevel.jl
@@ -6,20 +6,20 @@
     parsed = CSTParser.parse(text, true)
 
     # basic -- finds every toplevel items when `mod` options is `nothing` (default)
-    @test filter(toplevelitems(parsed, text; mod = nothing)) do item
+    @test filter(toplevelitems(text; mod = nothing)) do item
         item isa Atom.ToplevelBinding &&
         item.bind.name == "imwithdoc"
     end |> length === 3
 
     # don't enter non-target modules, e.g.: submodules
-    @test filter(toplevelitems(parsed, text; mod = "Junk")) do item
+    @test filter(toplevelitems(text; mod = "Junk")) do item
         item isa Atom.ToplevelBinding &&
         item.bind.name == "imwithdoc"
     end |> length === 1 # should only find the `imwithdoc` in Junk module
 
     # don't include items outside of a module
     # FIX: currently broken -- include `imwithdoc` in Junk module as well
-    @test_broken filter(toplevelitems(parsed, text; mod = "SubJunk")) do item
+    @test_broken filter(toplevelitems(text; mod = "SubJunk")) do item
         item isa Atom.ToplevelBinding &&
         item.bind.name == "imwithdoc"
     end |> length === 1 # should only find the `imwithdoc` in SubJunk module

--- a/test/workspace.jl
+++ b/test/workspace.jl
@@ -19,7 +19,7 @@
     end
 
     # recoginise submodule
-    let items = filter(i -> i[:name] == :Junk2, items)
+    let items = filter(i -> i[:name] == :SubJunk, items)
         @test !isempty(items)
         @test items[1][:type] == "module"
         @test items[1][:icon] == "icon-package"


### PR DESCRIPTION
### main purpose

fixes module escaping issues within CSTPraser-based module traverse
- [x] fixes that it can enter into submodules when searched from the parent module
- [x] fixes that it can include items outside of modules in the entry file (e.g. [`isdebugging` in `Atom` module](https://github.com/JunoLab/Atom.jl/blob/master/src/debugger/debugger.jl#L13) when we traverse `Atom.JunoDebugger`)

That would make goto and rename refactors (https://github.com/JunoLab/Atom.jl/pull/203) more "correct", and may also help https://github.com/JunoLab/Juno.jl/issues/411.

### sub note

I also included changes that enables gotos within unsaved editors
