### PR TITLE
more memory efficient SYMBOLSCACHE

### DIFF
--- a/src/goto.jl
+++ b/src/goto.jl
@@ -220,15 +220,6 @@ function filtertoplevelitem(word, bind::ToplevelBinding)
   bind = bind.bind
   bind === nothing ? false : word == bind.name
 end
-function filtertoplevelitem(word, tupleh::ToplevelTupleH)
-  expr = tupleh.expr
-  for arg in expr.args
-    if str_value(arg) == word
-      return true
-    end
-  end
-  return false
-end
 
 function GotoItem(path::String, bind::ToplevelBinding)
   expr = bind.expr
@@ -238,13 +229,6 @@ function GotoItem(path::String, bind::ToplevelBinding)
     text = str_value(sig)
   end
   line = bind.lines.start - 1
-  secondary = string(path, ":", line + 1)
-  GotoItem(text, path, line, secondary)
-end
-function GotoItem(path::String, tupleh::ToplevelTupleH)
-  expr = tupleh.expr
-  text = str_value(expr)
-  line = tupleh.lines.start - 1
   secondary = string(path, ":", line + 1)
   GotoItem(text, path, line, secondary)
 end

--- a/src/modules.jl
+++ b/src/modules.jl
@@ -3,10 +3,10 @@ finding all the included files for a module
 
 1. Revise-like approach
   * mostly adapted from https://github.com/timholy/Revise.jl/tree/b0c5c864ea78b93caaa820cb9cfc45eca47f43ff
-  * only works for precompiled modules
+  * reflects runtime information i.e. more precise
+  * NOTE: only works for precompiled modules
 2. CSTPraser-based approach
-  * static parsing -- works for all the files but costly
-  * TODO: excludes files in submodules when searched from the parent module
+  * static parsing -- works for all the modules
   * TODO: looks for non-toplevel `include` calls
 =#
 

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -76,18 +76,3 @@ function outlineitem(call::ToplevelCall)
 
     return nothing
 end
-function outlineitem(tupleh::ToplevelTupleH)
-    expr = tupleh.expr
-    lines = tupleh.lines
-
-    # `expr.parent` is always `CSTParser.EXPR`
-    type = isconstexpr(expr.parent) ? "constant" : "variable"
-    icon = isconstexpr(expr.parent) ? "c" : "v"
-
-    Dict(
-        :name  => str_value(expr),
-        :type  => type,
-        :icon  => icon,
-        :lines => [first(lines), last(lines)]
-    )
-end

--- a/src/static/local.jl
+++ b/src/static/local.jl
@@ -46,13 +46,13 @@ function localbindings(expr, text, bindings = [], pos = 1, line = 1)
 
         # destructure multiple returns
         if ismultiplereturn(expr)
-            for arg in expr.args
+            for arg in expr
                 # don't update `pos` & `line`, i.e.: treat all the multiple returns as same
                 localbindings(arg, text, bindings, pos, line)
             end
         # properly detect the parameters of a method with where clause: https://github.com/JunoLab/Juno.jl/issues/404
         elseif iswhereclause(expr)
-            for arg in expr.args
+            for arg in expr
                 localbindings(arg, text, bindings, pos, line)
                 line += countlines(arg, text, pos)
                 pos += arg.fullspan
@@ -65,12 +65,10 @@ function localbindings(expr, text, bindings = [], pos = 1, line = 1)
             name = bind === nothing ? "" : bind.name
 
             children = []
-            if expr.args !== nothing
-                for arg in expr.args
-                    localbindings(arg, text, children, pos, line)
-                    line += countlines(arg, text, pos)
-                    pos += arg.fullspan
-                end
+            for arg in expr
+                localbindings(arg, text, children, pos, line)
+                line += countlines(arg, text, pos)
+                pos += arg.fullspan
             end
 
             push!(bindings, LocalScope(name, bindstr, range, line, children, expr))
@@ -80,12 +78,10 @@ function localbindings(expr, text, bindings = [], pos = 1, line = 1)
     end
 
     # look for more local bindings if exists
-    if expr.args !== nothing
-        for arg in expr.args
-            localbindings(arg, text, bindings, pos, line)
-            line += countlines(arg, text, pos)
-            pos += arg.fullspan
-        end
+    for arg in expr
+        localbindings(arg, text, bindings, pos, line)
+        line += countlines(arg, text, pos)
+        pos += arg.fullspan
     end
 
     return bindings

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -44,7 +44,7 @@ ismacrocall(expr::CSTParser.EXPR) = expr.typ === CSTParser.MacroCall
 
 function isinclude(expr::CSTParser.EXPR)
     expr.typ === CSTParser.Call &&
-        length(expr.args) === 4 &&
+        length(expr) === 4 &&
         expr.args[1].val == "include" &&
         expr.args[3].val isa String &&
         endswith(expr.args[3].val, ".jl")
@@ -55,7 +55,7 @@ ismodule(expr::CSTParser.EXPR) =
 
 function isdoc(expr::CSTParser.EXPR)
     expr.typ === CSTParser.MacroCall &&
-        length(expr.args) >= 1 &&
+        length(expr) >= 1 &&
         (
             expr.args[1].typ === CSTParser.GlobalRefDoc ||
             str_value(expr.args[1]) == "@doc"

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -52,34 +52,28 @@ function _toplevelitems(
         lines = line:line+countlines(expr, text, pos, false)
 
         # destructure multiple returns
-        if ismultiplereturn(expr) && shouldadd
+        if ismultiplereturn(expr)
             for arg in expr
-                if (bind = CSTParser.bindingof(arg)) !== nothing
-                    push!(items, ToplevelBinding(arg, bind, lines))
-                end
+                (bind = CSTParser.bindingof(arg)) !== nothing && push!(items, ToplevelBinding(arg, bind, lines))
             end
         end
 
         # toplevel call
-        if iscallexpr(expr) && shouldadd
-            push!(items, ToplevelCall(expr, lines, str_value_as_is(expr, text, pos)))
-        end
+        iscallexpr(expr) && push!(items, ToplevelCall(expr, lines, str_value_as_is(expr, text, pos)))
     end
 
     # look for more toplevel items in expr:
     if shouldenter(expr, mod)
-        if expr.args !== nothing
-            if ismodule(expr) && shouldentermodule(expr, mod)
-                inmod = true
-            end
-            for arg in expr
-                _toplevelitems(text, arg, items, line, pos; mod = mod, inmod = inmod)
-                line += countlines(arg, text, pos)
-                pos += arg.fullspan
-            end
+        if ismodule(expr) && shouldentermodule(expr, mod)
+            inmod = true
+        end
+        for arg in expr
+            _toplevelitems(text, arg, items, line, pos; mod = mod, inmod = inmod)
+            line += countlines(arg, text, pos)
+            pos += arg.fullspan
         end
     end
-    return items
+    items
 end
 
 function shouldenter(expr::CSTParser.EXPR, mod::Union{Nothing, String})

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -53,7 +53,7 @@ function _toplevelitems(
 
         # destructure multiple returns
         if ismultiplereturn(expr) && shouldadd
-            for arg in expr.args
+            for arg in expr
                 if (bind = CSTParser.bindingof(arg)) !== nothing
                     push!(items, ToplevelBinding(arg, bind, lines))
                 end
@@ -72,7 +72,7 @@ function _toplevelitems(
             if ismodule(expr) && shouldentermodule(expr, mod)
                 inmod = true
             end
-            for arg in expr.args
+            for arg in expr
                 _toplevelitems(text, arg, items, line, pos; mod = mod, inmod = inmod)
                 line += countlines(arg, text, pos)
                 pos += arg.fullspan

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -187,7 +187,7 @@
             path = junkpath
             text = read(path, String)
             @test filter(SYMBOLSCACHE[key][path]) do item
-                Atom.str_value(item.expr) == "toplevelval2"
+                item.name == "toplevelval2"
             end |> isempty
 
             # mock updatesymbol handler
@@ -199,7 +199,7 @@
 
             # check the cache is updated
             @test filter(SYMBOLSCACHE[key][path]) do item
-                Atom.str_value(item.expr) == word
+                item.name == word
             end |> !isempty
 
             let items = toplevelgotoitems(word, mod, path, newtext) .|> todict
@@ -211,7 +211,7 @@
             # re-update the cache
             updatesymbols(key, path, text)
             @test filter(SYMBOLSCACHE[key][path]) do item
-                Atom.str_value(item.expr) == word
+                item.name == word
             end |> isempty
 
             # don't error on fallback case

--- a/test/outline.jl
+++ b/test/outline.jl
@@ -92,16 +92,28 @@
                     ),
                     Dict(
                         :type => "variable",
-                        :name => "a, b",
+                        :name => "a",
+                        :icon => "v",
+                        :lines => [2, 2],
+                    ),
+                    Dict(
+                        :type => "variable",
+                        :name => "b",
                         :icon => "v",
                         :lines => [2, 2],
                     ),
                     Dict(
                         :type => "constant",
-                        :name => "c1, c2",
+                        :name => "c1",
                         :icon => "c",
                         :lines => [3, 3],
                     ),
+                    Dict(
+                        :type => "constant",
+                        :name => "c2",
+                        :icon => "c",
+                        :lines => [3, 3],
+                    )
                 ]
                 @test o ∈ os
             end


### PR DESCRIPTION
Don't let `SYMBOLSCACHE` eat memory like a horse -- now it only uses`4 MiB` after `julia-client: regenerate-symbol-cache` while it did `140 MiB` within the previous implementation.

refactors:
- only keep _simple_ data in `SYMBOLSCACHE`
- remove `ToplevelTupleH` struct: make the overall code much simpler