### PR TITLE
outline module usages

### DIFF
--- a/src/goto.jl
+++ b/src/goto.jl
@@ -233,14 +233,12 @@ function __collecttoplevelitems(mod::Union{Nothing, String}, entrypath::String, 
 end
 
 GotoItem(path::String, item::ToplevelItem) = GotoItem("", path) # fallback case
-function GotoItem(path::String, bind::ToplevelBinding)
-  expr = bind.expr
-  name = text = bind.bind.name
-  if CSTParser.has_sig(expr)
-    sig = CSTParser.get_sig(expr)
-    text = str_value(sig)
-  end
-  line = bind.lines.start - 1
+function GotoItem(path::String, binding::ToplevelBinding)
+  expr = binding.expr
+  bind = binding.bind
+  name = bind.name
+  text = CSTParser.has_sig(expr) ? str_value(CSTParser.get_sig(expr)) : name
+  line = binding.lines.start - 1
   GotoItem(name, text, path, line)
 end
 

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -43,7 +43,7 @@ outlineitem(call::ToplevelCall) = begin
         :name  => call.str,
         :type  => "module",
         :icon  => "icon-file-code",
-        :lines => [first(call.lines), last(call.lines)],
+        :lines => [first(call.lines), last(call.lines)]
     )
 
     nothing
@@ -57,7 +57,7 @@ outlineitem(macrocall::ToplevelMacroCall) = begin
         :name  => strlimit(first(split(macrocall.str, '\n')), 100),
         :type  => "snippet",
         :icon  => "icon-mention",
-        :lines => [first(macrocall.lines), last(macrocall.lines)],
+        :lines => [first(macrocall.lines), last(macrocall.lines)]
     )
 end
 outlineitem(usage::ToplevelModuleUsage) = begin

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -76,3 +76,14 @@ function outlineitem(call::ToplevelCall)
 
     return nothing
 end
+
+function outlineitem(statement::ToplevelModuleUsage)
+    expr = statement.expr
+    lines = statement.lines
+    Dict(
+        :name  => replace(str_value(expr), ":" => ": "),
+        :type  => "mixin",
+        :icon  => "icon-package",
+        :lines => [first(lines), last(lines)]
+    )
+end

--- a/src/static/local.jl
+++ b/src/static/local.jl
@@ -33,7 +33,7 @@ end
 
 function localbindings(expr, text, bindings = [], pos = 1, line = 1)
     # binding
-    bind = CSTParser.bindingof(expr)
+    bind = bindingof(expr)
     scope = scopeof(expr)
     if bind !== nothing && scope === nothing
         bindstr = str_value_as_is(bind, text, pos)

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -75,9 +75,13 @@ function iswhereclause(expr::CSTParser.EXPR)
 end
 
 function isconstexpr(expr::CSTParser.EXPR)
-    parent = CSTParser.parentof(expr)
-    parent === nothing ? false : parent.typ === CSTParser.Const
+    (parent = CSTParser.parentof(expr)) !== nothing &&
+        parent.typ === CSTParser.Const
 end
+
+ismoduleusage(expr::CSTParser.EXPR) = isimport(expr) || isexport(expr)
+isimport(expr::CSTParser.EXPR) = expr.typ === CSTParser.Import || expr.typ === CSTParser.Using
+isexport(expr::CSTParser.EXPR) = expr.typ === CSTParser.Export
 
 # string utilities
 # ----------------
@@ -122,6 +126,12 @@ function str_value(x::CSTParser.EXPR)
         return "; " * join(str_value(a) for a in x)
     elseif x.typ === CSTParser.IDENTIFIER || x.typ === CSTParser.LITERAL || x.typ === CSTParser.OPERATOR || x.typ === CSTParser.KEYWORD
         return CSTParser.str_value(x)
+    elseif x.typ === CSTParser.Using
+        "using " * join(str_value(a) for a in x)
+    elseif x.typ === CSTParser.Import
+        "import " * join(str_value(a) for a in x)
+    elseif x.typ === CSTParser.Export
+        "export " * join(str_value(a) for a in x)
     else
         return join(str_value(a) for a in x)
     end

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -1,4 +1,5 @@
 using CSTParser
+using CSTParser: bindingof
 
 #=
 utilities
@@ -65,7 +66,7 @@ end
 function ismultiplereturn(expr::CSTParser.EXPR)
     expr.typ === CSTParser.TupleH &&
         expr.args !== nothing &&
-        !isempty(filter(a -> CSTParser.bindingof(a) !== nothing, expr.args))
+        !isempty(filter(a -> bindingof(a) !== nothing, expr.args))
 end
 
 function iswhereclause(expr::CSTParser.EXPR)

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -38,12 +38,12 @@ end
 # is utilities
 # ------------
 
-iscallexpr(expr::CSTParser.EXPR) = expr.typ === CSTParser.Call || expr.typ === CSTParser.MacroCall
+iscallexpr(expr::CSTParser.EXPR) = expr.typ === CSTParser.Call
 
 ismacrocall(expr::CSTParser.EXPR) = expr.typ === CSTParser.MacroCall
 
 function isinclude(expr::CSTParser.EXPR)
-    expr.typ === CSTParser.Call &&
+    iscallexpr(expr) &&
         length(expr) === 4 &&
         expr.args[1].val == "include" &&
         expr.args[3].val isa String &&
@@ -54,7 +54,7 @@ ismodule(expr::CSTParser.EXPR) =
     expr.typ === CSTParser.ModuleH || expr.typ === CSTParser.BareModule
 
 function isdoc(expr::CSTParser.EXPR)
-    expr.typ === CSTParser.MacroCall &&
+    ismacrocall(expr) &&
         length(expr) >= 1 &&
         (
             expr.args[1].typ === CSTParser.GlobalRefDoc ||

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -76,8 +76,8 @@ function iswhereclause(expr::CSTParser.EXPR)
 end
 
 function isconstexpr(expr::CSTParser.EXPR)
-    (parent = CSTParser.parentof(expr)) !== nothing &&
-        parent.typ === CSTParser.Const
+    parent = CSTParser.parentof(expr)
+    parent !== nothing && parent.typ === CSTParser.Const
 end
 
 ismoduleusage(expr::CSTParser.EXPR) = isimport(expr) || isexport(expr)
@@ -95,12 +95,11 @@ function Base.countlines(expr::CSTParser.EXPR, text::String, pos::Int, full::Boo
     count(c -> c === eol, text[s:e])
 end
 
+# adapted from https://github.com/julia-vscode/DocumentFormat.jl/blob/b7e22ca47254007b5e7dd3c678ba27d8744d1b1f/src/passes.jl#L108
 """
     str_value(x::CSTParser.EXPR)
 
-Reconstruct source code from a `CSTParser.EXPR`.
-
-Adapted from https://github.com/julia-vscode/DocumentFormat.jl/blob/b7e22ca47254007b5e7dd3c678ba27d8744d1b1f/src/passes.jl#L108.
+_Reconstruct_ a source code from `x`.
 """
 function str_value(x::CSTParser.EXPR)
     if x.typ === CSTParser.PUNCTUATION
@@ -128,11 +127,11 @@ function str_value(x::CSTParser.EXPR)
     elseif x.typ === CSTParser.IDENTIFIER || x.typ === CSTParser.LITERAL || x.typ === CSTParser.OPERATOR || x.typ === CSTParser.KEYWORD
         return CSTParser.str_value(x)
     elseif x.typ === CSTParser.Using
-        "using " * join(str_value(a) for a in x)
+        return "using " * join(str_value(a) for a in x)
     elseif x.typ === CSTParser.Import
-        "import " * join(str_value(a) for a in x)
+        return "import " * join(str_value(a) for a in x)
     elseif x.typ === CSTParser.Export
-        "export " * join(str_value(a) for a in x)
+        return "export " * join(str_value(a) for a in x)
     else
         return join(str_value(a) for a in x)
     end
@@ -141,8 +140,7 @@ end
 """
     str_value_as_is(expr::CSTParser.EXPR, text::String, pos::Int)
 
-Extract `expr`'s source from `text`, starting at `pos`. Similar to `str_value`, but doesn't
-*reconstruct* the source code.
+_Extract_ a source code from `text` that corresponds to `expr`.
 """
 function str_value_as_is(expr::CSTParser.EXPR, text::String, pos::Int)
     endpos = pos + expr.span

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -16,7 +16,13 @@ end
 struct ToplevelCall <: ToplevelItem
     expr::CSTParser.EXPR
     lines::UnitRange{Int}
-    callstr::String
+    str::String
+end
+
+struct ToplevelMacroCall <: ToplevelItem
+    expr::CSTParser.EXPR
+    lines::UnitRange{Int}
+    str::String
 end
 
 struct ToplevelModuleUsage <: ToplevelItem
@@ -65,6 +71,9 @@ function _toplevelitems(
 
         # toplevel call
         iscallexpr(expr) && push!(items, ToplevelCall(expr, lines, str_value_as_is(expr, text, pos)))
+
+        # toplevel macro call
+        ismacrocall(expr) && push!(items, ToplevelMacroCall(expr, lines, str_value_as_is(expr, text, pos)))
 
         # module usages
         ismoduleusage(expr) && push!(items, ToplevelModuleUsage(expr, lines))

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -19,6 +19,11 @@ struct ToplevelCall <: ToplevelItem
     callstr::String
 end
 
+struct ToplevelModuleUsage <: ToplevelItem
+    expr::CSTParser.EXPR
+    lines::UnitRange{Int}
+end
+
 """
     toplevelitems(text; kwargs...)::Vector{ToplevelItem}
 
@@ -60,6 +65,9 @@ function _toplevelitems(
 
         # toplevel call
         iscallexpr(expr) && push!(items, ToplevelCall(expr, lines, str_value_as_is(expr, text, pos)))
+
+        # module usages
+        ismoduleusage(expr) && push!(items, ToplevelModuleUsage(expr, lines))
     end
 
     # look for more toplevel items in expr:

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -54,7 +54,7 @@ function _toplevelitems(
     # add items if `mod` isn't specified or in a target modle
     if mod === nothing || inmod
         # binding
-        bind = CSTParser.bindingof(expr)
+        bind = bindingof(expr)
         if bind !== nothing
             lines = line:line+countlines(expr, text, pos, false)
             push!(items, ToplevelBinding(expr, bind, lines))
@@ -65,7 +65,7 @@ function _toplevelitems(
         # destructure multiple returns
         if ismultiplereturn(expr)
             for arg in expr
-                (bind = CSTParser.bindingof(arg)) !== nothing && push!(items, ToplevelBinding(arg, bind, lines))
+                (bind = bindingof(arg)) !== nothing && push!(items, ToplevelBinding(arg, bind, lines))
             end
         end
 

--- a/test/outline.jl
+++ b/test/outline.jl
@@ -220,4 +220,42 @@
             @test call[:icon] == "icon-file-code"
         end
     end
+
+    # module usages
+    let str = """
+        module Mock
+        using Atom
+        using Atom: SYMBOLSCACHE
+        import Base: iterate
+        export mock
+        mock = :mock
+        end
+        """
+        items = outline(str)
+        @test length(items) === 6
+        let usage = items[2]
+            @test usage[:type] == "mixin"
+            @test usage[:name] == "using Atom"
+            @test usage[:icon] == "icon-package"
+            @test usage[:lines] == [2, 2]
+        end
+        let usage = items[3]
+            @test usage[:type] == "mixin"
+            @test usage[:name] == "using Atom: SYMBOLSCACHE"
+            @test usage[:icon] == "icon-package"
+            @test usage[:lines] == [3, 3]
+        end
+        let usage = items[4]
+            @test usage[:type] == "mixin"
+            @test usage[:name] == "import Base: iterate"
+            @test usage[:icon] == "icon-package"
+            @test usage[:lines] == [4, 4]
+        end
+        let usage = items[5]
+            @test usage[:type] == "mixin"
+            @test usage[:name] == "export mock"
+            @test usage[:icon] == "icon-package"
+            @test usage[:lines] == [5, 5]
+        end
+    end
 end


### PR DESCRIPTION
create `ToplevelModuleUsage` struct and shows them in outline:
![image](https://user-images.githubusercontent.com/40514306/69405978-57313000-0d44-11ea-8b8d-743bd0450614.png)

we may want to use them in modules.jl or goto.jl as well for more precise module traverse in the future

***

First I would like to merge #219 and the rebase this PR.