### PR TITLE
RFC: better documentation search

### DIFF
--- a/src/docs.jl
+++ b/src/docs.jl
@@ -9,12 +9,17 @@ handle("searchdocs") do data
     exportedonly = exportedOnly || false,
     allPackages || false
   ] = data
-  _searchdocs(
+  searchdocs′(
     needle;
     # kwargs to be passed to `DocSeeker.searchdocs`:
     # TODO: configuration for `maxreturns`
     loaded = !allPackages, mod = mod, exportedonly = exportedonly, name_only = name_only
   )
+end
+
+function searchdocs′(needle; kwargs...)
+  items = _searchdocs(needle; kwargs...)
+  return processdocs(items)
 end
 
 function _searchdocs(needle; kwargs...)
@@ -30,9 +35,11 @@ function _searchdocs(needle; kwargs...)
     return _searchdocs(nextneedle; nextkwargs...)
   end
 
-  items = @errs searchdocs(needle; kwargs...)
+  return items = @errs searchdocs(needle; kwargs...)
+end
 
-  if items isa EvalError
+function processdocs(items)
+  return if items isa EvalError
     errstr = sprint(showerror, items.err)
     err = startswith(errstr, "Please regenerate the") ?
             """
@@ -71,12 +78,16 @@ end
 
 handle("moduleinfo") do data
   @destruct [mod] = data
+  moduleinfo(mod)
+end
+
+function moduleinfo(mod)
   d, items = getmoduleinfo(mod)
   items = [renderitem(i) for i in items]
   Dict(:doc => view(d), :items => items)
 end
 
-getmoduleinfo(mod) = ispackage(mod) ? packageinfo(mod) : moduleinfo(mod)
+getmoduleinfo(mod) = ispackage(mod) ? packageinfo(mod) : modinfo(mod)
 ispackage(mod) = Base.find_package(mod) ≠ nothing
 
 function packageinfo(mod)
@@ -90,14 +101,13 @@ function packageinfo(mod)
           ), modulesymbols(mod)
 end
 
-function moduleinfo(mod)
-  header = if mod ∈ ("Core", "Base", "Main") || first(split(mod, '.')) == "Base"
-    "## Standard module `$(mod)`"
-  else
+function modinfo(mod)
+  header = (mod in ("Core", "Base", "Main") || first(split(mod, '.')) == "Base") ?
+    "## Standard module `$(mod)`" :
     "## Module `$mod`"
-  end * "\n---\n## Defined symbols:" |> renderMD
+  header *= "\n---\n## Defined symbols:"
 
-  header, modulesymbols(mod)
+  return renderMD(header), modulesymbols(mod)
 end
 
 function modulesymbols(mod)
@@ -108,7 +118,8 @@ end
 using Logging: with_logger
 using .Progress: JunoProgressLogger
 
-handle("regeneratedocs") do
+handle(() -> regeneratedocs(), "regeneratedocs")
+function regeneratedocs()
   with_logger(JunoProgressLogger()) do
     @errs DocSeeker.createdocsdb()
   end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1,0 +1,24 @@
+@testset "docs" begin
+  @testset "searchdocs" begin
+    using Atom: searchdocs′, _searchdocs
+
+    @test !searchdocs′("sin")[:error]
+        # module awareness
+    @test all(_searchdocs("getfield′"; mod = "Atom")) do (score, docobj)
+      docobj.mod == "Atom"
+    end
+        # strip module accessor
+    @test all(_searchdocs("Atom.getfield′"; mod = "Main")) do (score, docobj)
+      docobj.mod == "Atom"
+    end
+  end
+
+  @testset "moduleinfo" begin
+    using Atom: moduleinfo
+
+    @test_nowarn moduleinfo("Main")
+    @test all(moduleinfo("Atom")[:items]) do item
+      item[:mod] == "Atom"
+    end
+  end
+end


### PR DESCRIPTION
The main change is to improve documentation searches where the needle is like `Mod.needle`.
If `Mod` is available, this would automatically search `needle` in `Mod` module (the same logic as https://github.com/JunoLab/Atom.jl/pull/208)

This would overwrites an user's module specification (if specified),
(e.g.:
![image](https://user-images.githubusercontent.com/40514306/71090914-70b08500-21e7-11ea-8204-45a25616dca1.png)
would overwrite `Atom.JunoDebugger` spec to `JuliaInterpreter`)
but I believe that would be more preferable for reasons:
- an user intentionally type module prefix for these cases
- some documentation references includes module prefixes and they don't work as expected with the previous behaviour:
  * e.g: https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/master/src/construct.jl#L353

***

I also added some tests for this and other.