### PR TITLE
RFC: improve completion performance

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -230,11 +230,10 @@ function completiondetail_method!(comp)
   (i = findfirst(m -> repr(hash(m)) == fhash, ms)) === nothing && return
   m = ms[i]
 
-  argtypes = Base.tuple_type_tail(m.sig)
   sparams = Core.svec(sparam_syms(m)...)
   wa = Core.Compiler.Params(typemax(UInt))  # world age
   inf = try
-    Core.Compiler.typeinf_type(m, argtypes, sparams, wa)
+    Core.Compiler.typeinf_type(m, m.sig, sparams, wa)
   catch err
     nothing
   end
@@ -243,7 +242,7 @@ function completiondetail_method!(comp)
   fsym = Symbol(f)
   cangetdocs(mod, fsym) || return
   docs = try
-    Docs.doc(Docs.Binding(mod, fsym), argtypes)
+    Docs.doc(Docs.Binding(mod, fsym), Base.tuple_type_tail(m.sig))
   catch err
     ""
   end

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -145,6 +145,7 @@ completionsummary(mod, c::REPLCompletions.ModuleCompletion) = begin
 end
 # always show completion summary for `MethodCompletion`
 completionsummary(mod, c::REPLCompletions.MethodCompletion, suppress) = begin
+  mod = c.method.module
   ct = Symbol(c.func)
   cangetdocs(mod, ct) || return ""
   docs = try

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -187,13 +187,13 @@ getfield′(@nospecialize(object), name::Symbol, default = undefined) = isdefine
 getfield′(@nospecialize(object), name::AbstractString, default = undefined) = getfield′(object, Symbol(name), default)
 
 """
-    getmodule(mod::AbstractString)
-    getmodule(parent::Union{Nothing, Module}, mod::AbstractString)
-    getmodule(code::AbstractString, pos; filemod)
+    getmodule(mod::AbstractString)::Module
+    getmodule(parent::Union{Nothing, Module}, mod::AbstractString)::Module
+    getmodule(code::AbstractString, pos; filemod)::Module
 
 Calls `CodeTools.getmodule(args...)`, but returns `Main` instead of `nothing` in a fallback case.
 """
-getmodule(args...) = (m = CodeTools.getmodule(args...)) === nothing ? Main : m
+getmodule(args...)::Module = (m = CodeTools.getmodule(args...)) === nothing ? Main : m
 
 """
     getmethods(mod::Module, word::AbstractString)

--- a/test/completions.jl
+++ b/test/completions.jl
@@ -47,43 +47,29 @@
             end |> length == length(methods(push!))
         end
 
-        ## features
+        ## advanced features
         # - dynamic method addition
         # - shows module where the method defined in right label
         # - shows the infered return type in left label
-        let cs = comps(line)
-            @test filter(cs) do c
+        # HACK: this allows testing this in a same julia runtime
+        let mod = Main.eval(:(module $(gensym("tempmod"))
+                struct Singleton end
+            end))
+            @test filter(comps(line)) do c
                 c[:type] == "method" &&
-                c[:rightLabel] == "Atom" &&
+                c[:rightLabel] == string(mod) &&
                 c[:leftLabel] == "String"
             end |> isempty
-        end
-
-        @eval Atom begin
-            import Base: push!
-            push!(::Undefined) = "i'm such a dynamic push!"
-        end
-
-        let cs = comps(line)
-            @test filter(cs) do c
+            @eval mod begin
+                import Base: push!
+                push!(::Singleton) = ""
+            end
+            @test filter(comps(line)) do c
                 c[:type] == "method" &&
-                c[:rightLabel] == "Atom" &&
+                c[:rightLabel] == string(mod) &&
                 c[:leftLabel] == "String" &&
-                c[:text] == "push!(::Atom.Undefined)"
+                c[:text] == "push!(::$(mod).Singleton)"
             end |> !isempty
-        end
-
-        ## advanced
-        line *= "Undefined(), "
-        let cs = comps(line) # in Main: Undefined is not defined -- should show all push! methods
-            @test length(cs) == length(methods(push!))
-        end
-
-        let c = comps(line, mod = Atom)[1] # in Atom: show push!(::Undefined) **first**
-            @test c[:type] == "method"
-            @test c[:rightLabel] == "Atom"
-            @test c[:leftLabel] == "String"
-            @test c[:text] == "push!(::Atom.Undefined)"
         end
     end
 

--- a/test/completions.jl
+++ b/test/completions.jl
@@ -2,7 +2,7 @@
     using REPL.REPLCompletions: completions
 
     comps(line; mod = "Main", context = "", row = 1, column = 1, force = false) =
-        Atom.basecompletionadapter(line, mod, context, row, column, force)[1]
+        Atom.basecompletionadapter(line, mod, context, row, column, force)
 
     @testset "module completion" begin
         ## basic
@@ -131,7 +131,7 @@
     end
 
     # don't error on fallback case
-    @test_nowarn @test Atom.basecompletionadapter("") == ([], "")
+    @test_nowarn @test Atom.basecompletionadapter("") == []
 end
 
 @testset "local completions" begin
@@ -151,19 +151,19 @@ end
         end
         """
         prefix = "a"
-        let c = Atom.basecompletionadapter(prefix, "Main", context, 3, 6)[1][1]
+        let c = Atom.basecompletionadapter(prefix, "Main", context, 3, 6)[1]
             @test c[:text] == "aaa"
             @test c[:rightLabel] == "foo"
             @test c[:type] == type
             @test c[:icon] == icon
         end
-        let c = Atom.basecompletionadapter(prefix, "Main", context, 6, 6)[1][1]
+        let c = Atom.basecompletionadapter(prefix, "Main", context, 6, 6)[1]
             @test c[:text] == "aaa"
             @test c[:rightLabel] == "foo"
             @test c[:type] == type
             @test c[:icon] == icon
         end
-        let c = Atom.basecompletionadapter(prefix, "Main", context, 8, 6)[1][1]
+        let c = Atom.basecompletionadapter(prefix, "Main", context, 8, 6)[1]
             @test c[:text] == "abc"
             @test c[:rightLabel] == "foo"
             @test c[:type] == type
@@ -171,7 +171,7 @@ end
         end
 
         # show all the local bindings in order when forcibly invoked
-        let cs = Atom.basecompletionadapter("", "Main", context, 6, 6, true)[1]
+        let cs = Atom.basecompletionadapter("", "Main", context, 6, 6, true)
             inds = findall(c -> c[:type] == type && c[:icon] == icon, cs)
             @test inds == [1, 2, 3, 4]
             @test map(c -> c[:text], cs[inds]) == ["foo", "aaa", "x", "abc"]
@@ -179,5 +179,5 @@ end
     end
 
     # don't error on fallback case
-    @test_nowarn @test Atom.localcompletions("", 1, 1) == []
+    @test_nowarn @test Atom.localcompletions("", 1, 1, "") == []
 end

--- a/test/completions.jl
+++ b/test/completions.jl
@@ -3,6 +3,8 @@
 
     comps(line; mod = "Main", context = "", row = 1, column = 1, force = false) =
         Atom.basecompletionadapter(line, mod, context, row, column, force)
+    # emurate `getSuggestionDetailsOnSelect`
+    add_details!(c) = Atom.completiondetail!(c)
 
     @testset "module completion" begin
         ## basic
@@ -55,6 +57,7 @@
             # - shows module where the method defined in right label
             # - shows the infered return type in left label
             @test filter(comps(line)) do c
+                add_details!(c)
                 c[:type] == "method" &&
                 c[:rightLabel] == string(mod) &&
                 c[:leftLabel] == "String" &&
@@ -66,6 +69,7 @@
                 push!(::Singleton) = ""
             end
             @test filter(comps(line)) do c
+                add_details!(c)
                 c[:type] == "method" &&
                 c[:rightLabel] == string(mod) &&
                 c[:leftLabel] == "String" &&
@@ -115,9 +119,10 @@
 
     @testset "keyword completion" begin
         @test filter(comps("begin")) do c
+            add_details!(c)
             c[:type] == "keyword" &&
-            c[:rightLabel] |> isempty &&
-            c[:description] |> !isempty
+            isempty(c[:rightLabel]) &&
+            !isempty(c[:description])
         end |> !isempty
     end
 


### PR DESCRIPTION
needs https://github.com/JunoLab/atom-julia-client/pull/663

***

### Rationale:

A profiling on `basecompletionadapter` shows [`completionsummary`](https://github.com/JunoLab/Atom.jl/blob/master/src/completions.jl#L108-L126) took much time -- this is obvious because retrieving a doc string is done by calling [`include_string` in `getdocs`](https://github.com/JunoLab/Atom.jl/blob/avi/optimcomps/src/utils.jl#L217-L234).
As a consequence, sometimes I can't get completions because of [the racing in frontend](https://github.com/JunoLab/atom-julia-client/blob/avi/optimcomps/lib/runtime/completions.js#L50) (which is good thing though) when there are many of suggestion (say, >100).

So I would like to simply suppress them when there are so many of completion suggestions, because I guess showing completion descriptions when there are many of them is not so usuful.
(as an heuristic, I made an threshold to [30](https://github.com/JunoLab/Atom.jl/blob/avi/optimcomps/src/completions.jl#L78) but this is obviously subject to discussion)

And autocomplete-plus only shows [at most 200 suggestions](https://github.com/atom/autocomplete-plus/blob/master/lib/suggestion-list-element.js#L49), so I made a corresponding threshold in the backend as well so that we can avoid useless computation.

### Achievement

On my machine `basecompletionadapter` now runs 6x times better (and defeating in the race never happens after JIT compiles)

### Misc

As a general improvement, I did some rename refactors (that would make namings more consistent with the other part of code bases), and changed the order of pushing local completions (since `pushfirst` isn't optimal)