### PR TITLE
recursive Project.toml search

### DIFF
--- a/src/misc.jl
+++ b/src/misc.jl
@@ -19,9 +19,26 @@ handle("cd") do path
   end
 end
 
-handle("activateProject") do path
+handle("activateProject") do dir
   hideprompt() do
+    if (path = find_project_file(dir)) === nothing
+      @warn "No project file found for `$dir`"
+      return
+    end
     Pkg.activate(path)
+  end
+end
+
+function find_project_file(dir)
+  while true
+    next_dir = dirname(dir)
+    (
+      next_dir == dir || # ensure to escape infinite recursion
+      isempty(dir)       # reached to the system root
+    ) && return nothing
+    path = joinpath(dir, "Project.toml")
+    isfile(path) && return path
+    dir = next_dir
   end
 end
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -21,6 +21,12 @@ end
 
 handle("activateProject") do dir
   hideprompt() do
+    Pkg.activate(dir)
+  end
+end
+
+handle("activateParentProject") do dir
+  hideprompt() do
     if (path = find_project_file(dir)) === nothing
       @warn "No project file found for `$dir`"
       return

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -69,14 +69,13 @@ function finddevpackages()
   sort(devpkgs)
 end
 
-function basepath(file)
-  srcdir = joinpath(Sys.BINDIR,"..","..","base")
-  releasedir = joinpath(Sys.BINDIR,"..","share","julia","base")
-  normpath(joinpath(isdir(srcdir) ? srcdir : releasedir, file))
-end
+const SRC_DIR = joinpath(Sys.BINDIR,"..","..","base")
+const RELEASE_DIR = joinpath(Sys.BINDIR,"..","share","julia","base")
+basepath(file) =
+  normpath(joinpath((@static isdir(SRC_DIR) ? SRC_DIR : RELEASE_DIR), file))
 
 fullpath(path) =
-  (isuntitled(path) || isabspath(path) ? path : basepath(path)) |> realpath′
+  realpath′(isuntitled(path) || isabspath(path) ? path : basepath(path))
 
 function pkgpath(path)
   m = match(r"((?:[^/\\]+[/\\]){2}src[/\\].*)$", path)

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -75,7 +75,7 @@
 
         @testset "goto modules" begin
             let item = globalgotoitems("Atom", Main, nothing, "")[1] |> todict
-                @test item[:file] == joinpath′(atomjldir, "Atom.jl")
+                @test item[:file] == joinpath′(atomsrcdir, "Atom.jl")
                 @test item[:line] == 3
             end
             let item = globalgotoitems("SubJunk", Junk, nothing, "")[1] |> todict
@@ -86,7 +86,7 @@
 
         @testset "goto toplevel symbols" begin
             ## where Revise approach works, i.e.: precompiled modules
-            let path = joinpath′(atomjldir, "comm.jl")
+            let path = joinpath′(atomsrcdir, "comm.jl")
                 mod = Atom
                 key = "Atom"
                 word = "handlers"
@@ -170,12 +170,12 @@
             let path = joinpath′(@__DIR__, "runtests.jl")
                 text = read(path, String)
                 mod = Main
-                word = "atomjldir"
+                word = "atomsrcdir"
 
                 items = toplevelgotoitems(word, mod, path, text) .|> todict
                 @test !isempty(items)
                 @test items[1][:file] == path
-                @test items[1][:line] == 5
+                @test items[1][:line] == 6
                 @test items[1][:text] == word
             end
 

--- a/test/modules.jl
+++ b/test/modules.jl
@@ -3,7 +3,7 @@
         using Atom: moduledefinition
 
         let (path, line) = moduledefinition(Atom)
-            @test path == atommodfile
+            @test path == atomjlfile
             @test line == 4
         end
         let (path, line) = moduledefinition(Junk)
@@ -34,7 +34,7 @@
         @test_broken junkpath == modulefiles(Junk)[1]
 
         ## CSTPraser-based module file detection
-        let included_files = normpath.(modulefiles("Atom", atommodfile))
+        let included_files = normpath.(modulefiles("Atom", atomjlfile))
             # finds all the files in Atom module except display/webio.jl
             for f in atommodfiles
                 f == webiofile && continue

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,16 +3,17 @@ using Atom, Test, JSON, Logging, CSTParser, Example
 
 joinpath′(files...) = Atom.fullpath(joinpath(files...))
 
-atomjldir = joinpath′(@__DIR__, "..", "src")
-atommodfile = joinpath′(atomjldir, "Atom.jl")
-webiofile = joinpath′(atomjldir, "display", "webio.jl")
+atomjldir = joinpath′(@__DIR__, "..")
+atomsrcdir = joinpath′(atomjldir, "src")
+atomjlfile = joinpath′(atomsrcdir, "Atom.jl")
+webiofile = joinpath′(atomsrcdir, "display", "webio.jl")
 
 # files in `Atom` module (except files in its submodules)
 atommodfiles = let
     files = []
-    debuggerdir = joinpath′(atomjldir, "debugger")
-    profilerdir = joinpath′(atomjldir, "profiler")
-    for (d, ds, fs) in walkdir(atomjldir)
+    debuggerdir = joinpath′(atomsrcdir, "debugger")
+    profilerdir = joinpath′(atomsrcdir, "profiler")
+    for (d, ds, fs) in walkdir(atomsrcdir)
         # NOTE: update directories below when you create an new submodule
         # the 2 files below are in Atom module
         if d == debuggerdir

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -48,6 +48,23 @@ end
     @test Atom.finddevpackages() isa AbstractDict
 end
 
+@testset "finding project file" begin
+    using Atom: find_project_file
+
+    # when exists
+    atomjl_project_file_path = joinpath′(atomjldir, "Project.toml")
+    @test atomjl_project_file_path == find_project_file(atomjldir)
+    @test atomjl_project_file_path == find_project_file(atomsrcdir)
+    @test atomjl_project_file_path == find_project_file(joinpath′(atomsrcdir, "debugger"))
+    @test atomjl_project_file_path == find_project_file(@__DIR__)
+    @test atomjl_project_file_path == find_project_file(joinpath′(@__DIR__, "fixtures"))
+
+    # when unexist
+    @test nothing === find_project_file("")
+    @test nothing === find_project_file("/home/user/foo/")
+    @test nothing === find_project_file("C:\\Users\\foo") # don't fail into infinite calls
+end
+
 # TODO: baselink, edit
 
 cd(old_pwd)


### PR DESCRIPTION
Enables `julia-client: activate-environment-in-current-folder` command to work when invoked from any dir under the `Project.toml` file