### PR TITLE
update to latest CSTParser

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 WebSockets = "104b5d7c-a370-577a-8038-80a2059c5097"
 
 [compat]
-CSTParser = "~1.0.0"
+CSTParser = "^1.1, ^2"
 CodeTools = "^0.6.4"
 CodeTracking = "^0.5.7"
 DocSeeker = "^0.3.1"

--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 WebSockets = "104b5d7c-a370-577a-8038-80a2059c5097"
 
 [compat]
-CSTParser = "^1.1, ^2"
+CSTParser = "=1.1.0, ^2"
 CodeTools = "^0.6.4"
 CodeTracking = "^0.5.7"
 DocSeeker = "^0.3.1"

--- a/src/static/bindings.jl
+++ b/src/static/bindings.jl
@@ -1,0 +1,260 @@
+#=
+Binding information for `EXPR`.
+
+NOTE:
+- Since we only want really basic information about `EXPR`, let's just add binding information
+    for `EXPR.meta` field for now.
+- Adapted from https://github.com/julia-vscode/StaticLint.jl/blob/619d2d7138e921e5748db32002051666ef2d54f0/src/bindings.jl
+=#
+
+struct Binding
+    name::String
+    val::Union{Binding,EXPR,Nothing}
+    # NOTE: omitted: type, refs, prev, next
+end
+function Binding(expr::EXPR, val::Union{Binding,EXPR,Nothing})
+    ex = CSTParser.get_name(expr)
+    name = if (name = valof(ex)) === nothing
+        typof(ex) === CSTParser.OPERATOR ? str_value(ex) : ""
+    else
+        name
+    end
+    return Binding(name, val)
+end
+Binding(expr::EXPR) = Binding(expr, expr)
+
+Base.show(io::IO, bind::Binding) = printstyled(io, ' ', "Binding(", bind.name, ')'; color = :blue)
+
+hasbinding(expr::EXPR) = expr.meta isa Binding
+bindingof(expr::EXPR)::Union{Nothing,Binding} = hasbinding(expr) ? expr.meta : nothing
+
+# adapted from https://github.com/julia-vscode/StaticLint.jl/blob/3a24e4b84a419ea607aaa51e42b3b45d172438c8/src/StaticLint.jl#L78-L113
+"""
+    traverse_expr!(x::EXPR)
+
+Iterates across the child nodes of an `EXPR` in execution order calling
+  [`mark_bindings`](@ref) on each node.
+"""
+function traverse_expr!(x::EXPR)
+    mark_bindings!(x)
+
+    if typof(x) === CSTParser.BinaryOpCall &&
+       (
+        CSTParser.is_assignment(x) && !CSTParser.is_func_call(x.args[1]) ||
+        typof(x.args[2]) === CSTParser.Tokens.DECLARATION
+       ) &&
+       !(CSTParser.is_assignment(x) && typof(x.args[1]) === CSTParser.Curly)
+        traverse_expr!(x.args[3])
+        traverse_expr!(x.args[2])
+        traverse_expr!(x.args[1])
+    elseif typof(x) === CSTParser.WhereOpCall
+        @inbounds for i = 3:length(x.args)
+            traverse_expr!(x.args[i])
+        end
+        traverse_expr!(x.args[1])
+        traverse_expr!(x.args[2])
+    elseif typof(x) === CSTParser.Generator
+        @inbounds for i = 2:length(x.args)
+            traverse_expr!(x.args[i])
+        end
+        traverse_expr!(x.args[1])
+    elseif typof(x) === CSTParser.Flatten &&
+           x.args !== nothing && length(x.args) === 1 &&
+           x.args[1].args !== nothing &&
+           length(x.args[1]) >= 3 && length(x.args[1].args[1]) >= 3
+        for i = 3:length(x.args[1].args[1].args)
+            traverse_expr!(x.args[1].args[1].args[i])
+        end
+        for i = 3:length(x.args[1].args)
+            traverse_expr!(x.args[1].args[i])
+        end
+        traverse_expr!(x.args[1].args[1].args[1])
+    elseif x.args !== nothing
+        @inbounds for i = 1:length(x.args)
+            traverse_expr!(x.args[i])
+        end
+    end
+end
+
+function mark_bindings!(x::EXPR)
+    hasbinding(x) && return
+
+    if typof(x) === CSTParser.BinaryOpCall
+        if kindof(x.args[2]) === CSTParser.Tokens.EQ
+            if CSTParser.is_func_call(x.args[1])
+                mark_binding!(x)
+                mark_sig_args!(x.args[1])
+            elseif typof(x.args[1]) === CSTParser.Curly
+                mark_typealias_bindings!(x)
+            else
+                mark_binding!(x.args[1], x)
+            end
+        elseif kindof(x.args[2]) === CSTParser.Tokens.ANON_FUNC
+            mark_binding!(x.args[1], x)
+        end
+    elseif typof(x) === CSTParser.WhereOpCall
+        for i = 3:length(x.args)
+            typof(x.args[i]) === CSTParser.PUNCTUATION && continue
+            mark_binding!(x.args[i])
+        end
+    elseif typof(x) === CSTParser.For
+        markiterbinding!(x.args[2])
+    elseif typof(x) === CSTParser.Generator
+        for i = 3:length(x.args)
+            typof(x.args[i]) === CSTParser.PUNCTUATION && continue
+            markiterbinding!(x.args[i])
+        end
+    elseif typof(x) === CSTParser.Filter
+        for i = 1:length(x.args)-2
+            typof(x.args[i]) === CSTParser.PUNCTUATION && continue
+            markiterbinding!(x.args[i])
+        end
+    elseif typof(x) === CSTParser.Do
+        if typof(x.args[3]) === CSTParser.TupleH
+            for i = 1:length(x.args[3].args)
+                typof(x.args[3].args[i]) === CSTParser.PUNCTUATION && continue
+                mark_binding!(x.args[3].args[i])
+            end
+        end
+        # markiterbinding!(x.args[3])
+    elseif typof(x) === CSTParser.FunctionDef
+        name = CSTParser.get_name(x)
+        # mark external binding
+        x.meta = Binding(name, x)
+        mark_sig_args!(CSTParser.get_sig(x))
+    elseif typof(x) === CSTParser.ModuleH || typof(x) === CSTParser.BareModule
+        x.meta = Binding(x.args[2], x)
+    elseif typof(x) === CSTParser.Macro
+        name = CSTParser.get_name(x)
+        x.meta = Binding(name, x)
+        mark_sig_args!(CSTParser.get_sig(x))
+    elseif typof(x) === CSTParser.Try && length(x.args) > 3
+        mark_binding!(x.args[4])
+    elseif typof(x) === CSTParser.Abstract || typof(x) === CSTParser.Primitive
+        name = CSTParser.get_name(x)
+        x.meta = Binding(name, x)
+        mark_parameters(CSTParser.get_sig(x))
+    elseif typof(x) === CSTParser.Mutable || typof(x) === CSTParser.Struct
+        name = CSTParser.get_name(x)
+        x.meta = Binding(name, x)
+        mark_parameters(CSTParser.get_sig(x))
+        blocki = typof(x.args[3]) === CSTParser.Block ? 3 : 4
+        for i = 1:length(x.args[blocki])
+            CSTParser.defines_function(x.args[blocki].args[i]) && continue
+            mark_binding!(x.args[blocki].args[i])
+        end
+    elseif typof(x) === CSTParser.Local
+        if length(x.args) == 2
+            if typof(x.args[2]) === CSTParser.IDENTIFIER
+                mark_binding!(x.args[2])
+            elseif typof(x.args[2]) === CSTParser.TupleH
+                for i = 1:length(x.args[2].args)
+                    if typof(x.args[2].args[i]) === CSTParser.IDENTIFIER
+                        mark_binding!(x.args[2].args[i])
+                    end
+                end
+            end
+        end
+    end
+end
+
+function mark_binding!(x::EXPR, val = x)
+    if typof(x) === CSTParser.Kw
+        mark_binding!(x.args[1], x)
+    elseif typof(x) === CSTParser.TupleH || typof(x) === CSTParser.Parameters
+        for arg in x.args
+            typof(arg) === CSTParser.PUNCTUATION && continue
+            mark_binding!(arg, val)
+        end
+    elseif typof(x) === CSTParser.BinaryOpCall &&
+           kindof(x.args[2]) === CSTParser.Tokens.DECLARATION &&
+           typof(x.args[1]) === CSTParser.TupleH
+        mark_binding!(x.args[1], x)
+    elseif typof(x) === CSTParser.InvisBrackets
+        mark_binding!(CSTParser.rem_invis(x), val)
+    elseif typof(x) == CSTParser.UnaryOpCall &&
+           kindof(x.args[1]) === CSTParser.Tokens.DECLARATION
+        return x
+    else# if typof(x) === IDENTIFIER || (typof(x) === BinaryOpCall && kindof(x.args[2]) === CSTParser.Tokens.DECLARATION)
+        x.meta = Binding(CSTParser.get_name(x), val)
+    end
+    return x
+end
+
+function mark_parameters(sig::EXPR)
+    signame = CSTParser.rem_where_subtype(sig)
+    if typof(signame) === CSTParser.Curly
+        for i = 3:length(signame.args)-1
+            if typof(signame.args[i]) !== CSTParser.PUNCTUATION
+                mark_binding!(signame.args[i])
+            end
+        end
+    end
+    return sig
+end
+
+function markiterbinding!(iter::EXPR)
+    if typof(iter) === CSTParser.BinaryOpCall &&
+       kindof(iter.args[2]) in (CSTParser.Tokens.EQ, CSTParser.Tokens.IN, CSTParser.Tokens.ELEMENT_OF)
+        mark_binding!(iter.args[1], iter)
+    elseif typof(iter) === CSTParser.Block
+        for i = 1:length(iter.args)
+            typof(iter.args[i]) === CSTParser.PUNCTUATION && continue
+            markiterbinding!(iter.args[i])
+        end
+    end
+    return iter
+end
+
+function mark_sig_args!(x::EXPR)
+    if typof(x) === CSTParser.Call || typof(x) === CSTParser.TupleH
+        if typof(x.args[1]) === CSTParser.InvisBrackets &&
+           typof(x.args[1].args[2]) === CSTParser.BinaryOpCall &&
+           kindof(x.args[1].args[2].args[2]) === CSTParser.Tokens.DECLARATION
+            mark_binding!(x.args[1].args[2])
+        end
+        for i = 2:length(x.args)-1
+            a = x.args[i]
+            if typof(a) === CSTParser.Parameters
+                for j = 1:length(a.args)
+                    aa = a.args[j]
+                    if !(typof(aa) === CSTParser.PUNCTUATION)
+                        mark_binding!(aa)
+                    end
+                end
+            elseif !(typof(a) === CSTParser.PUNCTUATION)
+                mark_binding!(a)
+            end
+        end
+    elseif typof(x) === CSTParser.WhereOpCall
+        for i = 3:length(x.args)
+            if !(typof(x.args[i]) === CSTParser.PUNCTUATION)
+                mark_binding!(x.args[i])
+            end
+        end
+        mark_sig_args!(x.args[1])
+    elseif typof(x) === CSTParser.BinaryOpCall
+        if kindof(x.args[2]) == CSTParser.Tokens.DECLARATION
+            mark_sig_args!(x.args[1])
+        else
+            mark_binding!(x.args[1])
+            mark_binding!(x.args[3])
+        end
+    elseif typof(x) == CSTParser.UnaryOpCall && typof(x.args[2]) == CSTParser.InvisBrackets
+        mark_binding!(x.args[2].args[2])
+    end
+end
+
+function mark_typealias_bindings!(x::EXPR)
+    mark_binding!(x, x)
+    for i = 2:length(x.args[1].args)
+        if typof(x.args[1].args[i]) === CSTParser.IDENTIFIER
+            mark_binding!(x.args[1].args[i])
+        elseif typof(x.args[1].args[i]) === CSTParser.BinaryOpCall &&
+               kindof(x.args[1].args[i].args[2]) === CSTParser.Tokens.ISSUBTYPE &&
+               typof(x.args[1].args[i].args[1]) === CSTParser.IDENTIFIER
+            mark_binding!(x.args[1].args[i].args[1])
+        end
+    end
+    return x
+end

--- a/src/static/scope.jl
+++ b/src/static/scope.jl
@@ -11,18 +11,21 @@ NOTE:
 function hasscope(x::EXPR)
     t = typof(x)
 
-    # added conditions below when adapted
-    if t === CSTParser.Call && (p = parentof(x)) !== nothing && !hasscope(p)
+    # NOTE: added conditions below when adapted
+    if t === CSTParser.TupleH && (p = parentof(x)) !== nothing && !hasscope(p)
         return true
-    elseif t === CSTParser.TupleH && (p = parentof(x)) !== nothing && !hasscope(p)
-        return true
+    # # XXX:
+    # # introduced in https://github.com/JunoLab/Atom.jl/commit/7de5299001395b83bab0cb9d102e3f36d5c202d1
+    # # but now this seems to include bad cases for function arguments
+    # elseif t === CSTParser.Call && (p = parentof(x)) !== nothing && !hasscope(p)
+    #     return true
     elseif iswhereclause(x)
         return true
     elseif t === CSTParser.MacroCall
         return true
     elseif t === CSTParser.Quote
         return true
-    # adaption ended
+    # NOTE: end
 
     elseif t === CSTParser.BinaryOpCall
         k = kindof(x.args[2])

--- a/src/static/scope.jl
+++ b/src/static/scope.jl
@@ -1,0 +1,104 @@
+#=
+Scope information for `EXRR`.
+
+NOTE:
+- StaticLint.jl adds various scope-related information for `EXPR.meta.scope` field,
+    but we currently just need to know whether `EXPR` introduces a scope or not.
+    So let's just make a function to check that, and don't fill `EXPR` with scope information.
+- Adapted from https://github.com/julia-vscode/StaticLint.jl/blob/cd8935a138caf18385c46db977b52c5ac9e90809/src/scope.jl
+=#
+
+function hasscope(x::EXPR)
+    t = typof(x)
+
+    # added conditions below when adapted
+    if t === CSTParser.Call && (p = parentof(x)) !== nothing && !hasscope(p)
+        return true
+    elseif t === CSTParser.TupleH && (p = parentof(x)) !== nothing && !hasscope(p)
+        return true
+    elseif iswhereclause(x)
+        return true
+    elseif t === CSTParser.MacroCall
+        return true
+    elseif t === CSTParser.Quote
+        return true
+    # adaption ended
+
+    elseif t === CSTParser.BinaryOpCall
+        k = kindof(x.args[2])
+        if k === Tokens.EQ && CSTParser.is_func_call(x.args[1])
+            return true
+        elseif k === Tokens.EQ && typof(x.args[1]) === CSTParser.Curly
+            return true
+        elseif k === Tokens.ANON_FUNC
+            return true
+        else
+            return false
+        end
+    # # NOTE: commented out when adapted
+    # elseif t === CSTParser.WhereOpCall
+    #     # unless in func def signature
+    #     return !_in_func_def(x)
+    elseif t === CSTParser.FunctionDef ||
+           t === CSTParser.Macro ||
+           t === CSTParser.For ||
+           t === CSTParser.While ||
+           t === CSTParser.Let ||
+           t === CSTParser.Generator || # and Flatten?
+           t === CSTParser.Try ||
+           t === CSTParser.Do ||
+           t === CSTParser.ModuleH ||
+           t === CSTParser.BareModule ||
+           t === CSTParser.Abstract ||
+           t === CSTParser.Primitive ||
+           t === CSTParser.Mutable ||
+           t === CSTParser.Struct
+        return true
+    end
+
+    return false
+end
+
+# # NOTE: commented out when adapted
+# # only called in WhereOpCall
+# function _in_func_def(x::EXPR)
+#     # check 1st arg contains a call (or op call)
+#     ex = x.args[1]
+#     while true
+#         if typof(ex) === CSTParser.WhereOpCall ||
+#            (
+#             typof(ex) === CSTParser.BinaryOpCall &&
+#             kindof(ex.args[2]) === CSTParser.Tokens.DECLARATION
+#            )
+#             ex = ex.args[1]
+#         elseif typof(ex) === CSTParser.Call ||
+#                (
+#                 typof(ex) === CSTParser.BinaryOpCall &&
+#                 !(kindof(ex.args[2]) === CSTParser.Tokens.DOT)
+#                ) ||
+#                typof(ex) == CSTParser.UnaryOpCall #&& kindof(ex.args[1]) == CSTParser.Tokens.MINUS
+#             break
+#         else
+#             return false
+#         end
+#     end
+#     # check parent is func def
+#     ex = x
+#     while true
+#         if !(parentof(ex) isa EXPR)
+#             return false
+#         elseif typof(parentof(ex)) === CSTParser.WhereOpCall ||
+#                typof(parentof(ex)) === CSTParser.InvisBrackets
+#             ex = parentof(ex)
+#         elseif typof(parentof(ex)) === CSTParser.FunctionDef ||
+#                (
+#                 typof(parentof(ex)) === CSTParser.BinaryOpCall &&
+#                 kindof(parentof(ex).args[2]) === CSTParser.Tokens.EQ
+#                )
+#             return true
+#         else
+#             return false
+#         end
+#     end
+#     return false
+# end

--- a/src/static/scope.jl
+++ b/src/static/scope.jl
@@ -14,11 +14,6 @@ function hasscope(x::EXPR)
     # NOTE: added conditions below when adapted
     if t === CSTParser.TupleH && (p = parentof(x)) !== nothing && !hasscope(p)
         return true
-    # # XXX:
-    # # introduced in https://github.com/JunoLab/Atom.jl/commit/7de5299001395b83bab0cb9d102e3f36d5c202d1
-    # # but now this seems to include bad cases for function arguments
-    # elseif t === CSTParser.Call && (p = parentof(x)) !== nothing && !hasscope(p)
-    #     return true
     elseif iswhereclause(x)
         return true
     elseif t === CSTParser.MacroCall

--- a/test/datatip.jl
+++ b/test/datatip.jl
@@ -12,7 +12,7 @@
               map(l -> localdatatip(l, word, startRow), ls)             # L8
             end                                                         # L9
             """,
-            localdatatip(word, line) = Atom.localdatatip(word, Inf, line + 1, 0, str)[1]
+            localdatatip(word, line) = Atom.localdatatip(word, typemax(Int), line + 1, 0, str)[1]
 
             @test localdatatip("row", 1) == 0 # line
             @test localdatatip("position", 2) == Dict(:type => :snippet, :value => "position = row - startRow") # binding string
@@ -27,7 +27,7 @@
                 return val
             end
             """,
-            localdatatip(word, line) = Atom.localdatatip(word, Inf, line + 1, 0, str)[1]
+            localdatatip(word, line) = Atom.localdatatip(word, typemax(Int), line + 1, 0, str)[1]
 
             @test localdatatip("expr.args", 1)[:value] == "expr::CSTParser.EXPR"
             @test localdatatip("bind.val", 2)[:value] == "bind = CSTParser.bindingof(expr.args[1])"

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -17,7 +17,7 @@
               end                                                              # L11
             end                                                                # L12
             """,
-            localgotoitem(word, line) = Atom.localgotoitem(word, "path", Inf, line + 1, 0, str)[1] |> todict
+            localgotoitem(word, line) = Atom.localgotoitem(word, "path", typemax(Int), line + 1, 0, str)[1] |> todict
 
             let item = localgotoitem("row", 2)
                 @test item[:line] === 0
@@ -37,7 +37,7 @@
                 return val
             end
             """,
-            localgotoitem(word, line) = Atom.localgotoitem(word, "path", Inf, line + 1, 0, str)[1] |> todict
+            localgotoitem(word, line) = Atom.localgotoitem(word, "path", typemax(Int), line + 1, 0, str)[1] |> todict
 
             @test localgotoitem("expr.args", 1)[:line] === 0
             @test localgotoitem("bind.val", 2)[:line] === 1

--- a/test/static/bindings.jl
+++ b/test/static/bindings.jl
@@ -1,0 +1,92 @@
+#=
+Test whether binding markings works correctly.
+
+Adapted from https://github.com/julia-vscode/CSTParser.jl/blob/e4e32477a1e7b4d57652b3755659f169b50fb60e/test/bindings.jl
+=#
+
+using Atom: traverse_expr!, bindingof
+using CSTParser: typof
+
+function collect_bindings(ex)
+    traverse_expr!(ex)
+    return _collect_bindings(ex)
+end
+function _collect_bindings(x, out = String[])
+    if bindingof(x) !== nothing
+        push!(out, bindingof(x).name)
+    end
+    if (typof(x) === CSTParser.BinaryOpCall && CSTParser.is_assignment(x) && !CSTParser.is_func_call(x)) || typof(x) === CSTParser.Filter
+        _collect_bindings(x.args[3], out)
+        _collect_bindings(x.args[2], out)
+        _collect_bindings(x.args[1], out)
+    elseif typof(x) === CSTParser.WhereOpCall
+        @inbounds for i = 3:length(x.args)
+            _collect_bindings(x.args[i], out)
+        end
+        _collect_bindings(x.args[1], out)
+        _collect_bindings(x.args[2], out)
+    elseif typof(x) === CSTParser.Generator
+        @inbounds for i = 2:length(x.args)
+            _collect_bindings(x.args[i], out)
+        end
+        _collect_bindings(x.args[1], out)
+    elseif x.args === nothing
+    else
+        @inbounds for a in x.args
+            _collect_bindings(a, out)
+        end
+    end
+    return out
+end
+
+@test collect_bindings(CSTParser.parse("x = 1")) == ["x"]
+@test collect_bindings(CSTParser.parse("(x) = 1")) == ["x"]
+@test collect_bindings(CSTParser.parse("x, y =  1")) == ["x", "y"]
+@test collect_bindings(CSTParser.parse("(x, y) =  1")) == ["x", "y"]
+@test collect_bindings(CSTParser.parse("x = y =  1")) == ["y", "x"]
+@test collect_bindings(CSTParser.parse("x::T = 1")) == ["x"]
+
+@test collect_bindings(CSTParser.parse("f() = x")) == ["f"]
+@test collect_bindings(CSTParser.parse("f(a) = x")) == ["f", "a"]
+@test collect_bindings(CSTParser.parse("f(a) = x")) == ["f", "a"]
+@test collect_bindings(CSTParser.parse("f(x::T) where {T <: S} where R = x")) == ["f", "R", "T","x"]
+@test collect_bindings(CSTParser.parse("function f end")) == ["f"]
+@test collect_bindings(CSTParser.parse("function f() end")) == ["f"]
+@test collect_bindings(CSTParser.parse("function f() where T end")) == ["f", "T"]
+
+@test collect_bindings(CSTParser.parse("macro m end")) == ["m"]
+@test collect_bindings(CSTParser.parse("macro m() end")) == ["m"]
+
+@test collect_bindings(CSTParser.parse("abstract type T end")) == ["T"]
+@test collect_bindings(CSTParser.parse("abstract type T <: S end")) == ["T"]
+@test collect_bindings(CSTParser.parse("abstract type T{S} end")) == ["T", "S"]
+
+@test collect_bindings(CSTParser.parse("primitive type T 4 end")) == ["T"]
+@test collect_bindings(CSTParser.parse("primitive type T <: S 4 end")) == ["T"]
+@test collect_bindings(CSTParser.parse("primitive type T{S} 4 end")) == ["T", "S"]
+
+@test collect_bindings(CSTParser.parse("struct T end")) == ["T"]
+@test collect_bindings(CSTParser.parse("struct T <: S end")) == ["T"]
+@test collect_bindings(CSTParser.parse("struct T{S} end")) == ["T" ,"S"]
+@test collect_bindings(CSTParser.parse("struct T\nx end")) == ["T", "x"]
+@test collect_bindings(CSTParser.parse("struct T\nT() = new()\n end")) == ["T", "T"]
+
+@test collect_bindings(CSTParser.parse("mutable struct T end")) == ["T"]
+
+@test collect_bindings(CSTParser.parse("for i = 1 end")) == ["i"]
+@test collect_bindings(CSTParser.parse("let i = 1 end")) == ["i"]
+@test collect_bindings(CSTParser.parse("[i for i = 1]")) == ["i"]
+@test collect_bindings(CSTParser.parse("[i for i in 1]")) == ["i"]
+@test collect_bindings(CSTParser.parse("try catch e end")) == ["e"]
+@test collect_bindings(CSTParser.parse("map() do x end")) == ["x"]
+
+@test collect_bindings(CSTParser.parse("(a,b)->x")) == ["a", "b"]
+collect_bindings(CSTParser.parse("function f(a::T = 1) end")) == ["f", "a"]
+
+let cst = CSTParser.parse("function a::T * b::T end")
+    traverse_expr!(cst)
+    @test bindingof(cst[2][1]) !== nothing
+    @test bindingof(cst[2][3]) !== nothing
+end
+
+@test collect_bindings(CSTParser.parse("-(x::T) = x")) == ["-", "x"]

--- a/test/static/local.jl
+++ b/test/static/local.jl
@@ -148,6 +148,23 @@ let str = """
     @test "push!′" in binds
 end
 
+# finds function arguments when the function is type-declared
+# ref: https://github.com/JunoLab/Atom.jl/issues/223
+let str = """
+    function func(ary::Vector{T}, i::Int)::T where {T<:Number}
+        # here
+        s = sum(ary[1:i])
+        return s
+    end
+    """
+
+    binds = map(l -> l[:name], Atom.locals(str, 2, 4))
+    @test "ary" in binds
+    @test "i" in binds
+    @test "T" in binds
+    @test "func" in binds
+end
+
 let str = """
     function foo(x)
         @macrocall begin

--- a/test/static/static.jl
+++ b/test/static/static.jl
@@ -1,4 +1,8 @@
 @testset "static analysis" begin
+    @testset "bindings" begin
+        include("bindings.jl")
+    end
+
     @testset "toplevel items" begin
         include("toplevel.jl")
     end


### PR DESCRIPTION
Fixes #226 .

Previous tests are almost never modified and so we now can update CSTParser while keeping all the functionalities we've implemented.
The basic binding test is added.

Later I'll add a small fix related to #223 .

TODO:
- [x] test `mark_bindings!` and stuff ?