### PR TITLE
refactor static features

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -176,10 +176,10 @@ localcompletions(text, row, col, prefix) = localcompletion.(locals(text, row, co
 localcompletion(l, prefix) = CompletionSuggetion(
   :replacementPrefix  => prefix,
   # suggestion body
-  :text               => l[:name],
-  :type               => l[:type] == "variable" ? "attribute" : l[:type],
-  :icon               => l[:icon] == "v" ? "icon-chevron-right" : l[:icon],
-  :rightLabel         => l[:root],
+  :text               => l.name,
+  :type               => (type = static_type(l)) == "variable" ? "attribute" : type,
+  :icon               => (icon = static_icon(l)) == "v" ? "icon-chevron-right" : icon,
+  :rightLabel         => l.root,
   # for `getSuggestionDetailsOnSelect` API
   :detailtype         => "", # shouldn't complete
 )

--- a/src/datatip.jl
+++ b/src/datatip.jl
@@ -39,17 +39,17 @@ function localdatatip(word, column, row, startrow, context)
   position = row - startrow
   ls = locals(context, position, column)
   filter!(ls) do l
-    l[:name] == word &&
-    l[:line] < position
+    l.name == word &&
+    l.line < position
   end
   # there should be zero or one element in `ls`
-  map(l -> localdatatip(l, word, startrow), ls)
+  return localdatatip.(ls, word, startrow)
 end
 
 function localdatatip(l, word, startrow)
-  verbatim = l[:verbatim]
+  verbatim = l.verbatim
   return if verbatim == word # when `word` is an argument or such
-    startrow + l[:line] - 1
+    startrow + l.line - 1
   else
     Dict(:type => :snippet, :value => verbatim)
   end

--- a/src/datatip.jl
+++ b/src/datatip.jl
@@ -47,11 +47,11 @@ function localdatatip(word, column, row, startrow, context)
 end
 
 function localdatatip(l, word, startrow)
-  bindstr = l[:bindstr]
-  return if bindstr == word # when `word` is an argument or such
+  verbatim = l[:verbatim]
+  return if verbatim == word # when `word` is an argument or such
     startrow + l[:line] - 1
   else
-    Dict(:type => :snippet, :value => bindstr)
+    Dict(:type => :snippet, :value => verbatim)
   end
 end
 

--- a/src/datatip.jl
+++ b/src/datatip.jl
@@ -38,10 +38,7 @@ function localdatatip(word, column, row, startrow, context)
   word = first(split(word, '.')) # always ignore dot accessors
   position = row - startrow
   ls = locals(context, position, column)
-  filter!(ls) do l
-    l.name == word &&
-    l.line < position
-  end
+  filter!(l -> l.name == word && l.line < position, ls)
   # there should be zero or one element in `ls`
   return localdatatip.(ls, word, startrow)
 end

--- a/src/goto.jl
+++ b/src/goto.jl
@@ -323,7 +323,7 @@ function regeneratesymbols()
   for (i, pkg) in enumerate(unloaded)
     try
       @logmsg -1 "Symbols: $pkg ($(i + loadedlen) / $total)" progress=(i+loadedlen)/total _id=id
-      path = Base.find_package(pkg)
+      (path = Base.find_package(pkg)) === nothing && continue
       SYMBOLSCACHE[pkg] = _collecttoplevelitems_static(pkg, path)
     catch err
       @error err

--- a/src/goto.jl
+++ b/src/goto.jl
@@ -75,16 +75,16 @@ function localgotoitem(word, path, column, row, startrow, context)
   position = row - startrow
   ls = locals(context, position, column)
   filter!(ls) do l
-    l[:name] == word &&
-    l[:line] < position
+    l.name == word &&
+    l.line < position
   end
-  map(ls) do l # there should be zero or one element in `ls`
-    name = l[:name]
-    line = startrow + l[:line] - 1
+  return map(ls) do l # there should be zero or one element in `ls`
+    name = l.name
+    line = startrow + l.line - 1
     GotoItem(name, path, line)
   end
 end
-localgotoitem(word, ::Nothing, column, row, startrow, context) = [] # when called from docpane/workspace
+localgotoitem(word, ::Nothing, column, row, startrow, context) = GotoItem[] # when called from docpane/workspace
 
 ### global goto - bundles toplevel gotos & method gotos
 

--- a/src/goto.jl
+++ b/src/goto.jl
@@ -74,10 +74,7 @@ function localgotoitem(word, path, column, row, startrow, context)
   word = first(split(word, '.')) # always ignore dot accessors
   position = row - startrow
   ls = locals(context, position, column)
-  filter!(ls) do l
-    l.name == word &&
-    l.line < position
-  end
+  filter!(l -> l.name == word && l.line < position, ls)
   return map(ls) do l # there should be zero or one element in `ls`
     name = l.name
     line = startrow + l.line - 1

--- a/src/modules.jl
+++ b/src/modules.jl
@@ -201,14 +201,14 @@ end
 # ------------------------
 
 """
-    included_files = modulefiles(mod::String, entrypath::String, files = Vector{String}(); inmod = false)::Set{String}
+    included_files = modulefiles(mod::String, entrypath::String; inmod::Bool = false)::Set{String}
 
 Returns all the files in `mod` module that can be reached via [`include`](@ref)
   calls from `entrypath`.
 Note this function currently only looks for static toplevel calls (i.e. miss the
   calls in non-toplevel scope).
 """
-function modulefiles(mod::String, entrypath::String, files = Set{String}(); inmod = false)
+function modulefiles(mod::String, entrypath::String, files = Set{String}(); inmod::Bool = false)::Set{String}
   isfile′(entrypath) || return files
   # escape recursive `include` loops
   # NOTE: report this appropriately (e.g. within linter)

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -54,9 +54,9 @@ end
 outlineitem(call::ToplevelCall) = begin
     # show includes
     return if isinclude(call.expr)
-        OutlineItem(call.str, "module", "icon-file-code", call)
+        OutlineItem(call.verbatim, "module", "icon-file-code", call)
     elseif isprecompile(call.expr)
-        OutlineItem(call.str, "module", "icon-file-binary", call)
+        OutlineItem(call.verbatim, "module", "icon-file-binary", call)
     else
         nothing
     end
@@ -65,8 +65,8 @@ outlineitem(macrocall::ToplevelMacroCall) = begin
     # don't show doc strings
     isdoc(macrocall.expr) && return nothing
     # show first line verbatim of macro calls
-    verbatim = strlimit(first(split(macrocall.str, '\n')), 100)
-    OutlineItem(verbatim, "snippet", "icon-mention", macrocall)
+    firstline = strlimit(first(split(macrocall.verbatim, '\n')), 100)
+    OutlineItem(firstline, "snippet", "icon-mention", macrocall)
 end
 outlineitem(usage::ToplevelModuleUsage) = begin
     useline = replace(str_value(usage.expr), ":" => ": ")

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -6,8 +6,8 @@ handle("updateeditor") do data
         updateSymbols || true
     ] = data
 
-    try
-        updateeditor(text, mod, path, updateSymbols)
+    return try
+        todict.(updateeditor(text, mod, path, updateSymbols))
     catch err
         []
     end
@@ -23,48 +23,52 @@ function updateeditor(text, mod = "Main", path = nothing, updateSymbols = true)
     outline(toplevelitems(text))
 end
 
-outline(items) = filter!(item -> item !== nothing, outlineitem.(items))
+struct OutlineItem
+    name::String
+    type::String
+    icon::String
+    start::Int
+    stop::Int
+end
+OutlineItem(name, type, icon, item::ToplevelItem) =
+    OutlineItem(name, type, icon, first(item.lines), last(item.lines))
+
+# for messaging over julia ⟷ Atom
+todict(item::OutlineItem) = Dict(
+    :name  => item.name,
+    :type  => item.type,
+    :icon  => item.icon,
+    :start => item.start,
+    :stop  => item.stop
+)
+
+outline(items)::Vector{OutlineItem} = filter!(item -> item !== nothing, outlineitem.(items))
 
 outlineitem(item::ToplevelItem) = nothing # fallback case
 outlineitem(binding::ToplevelBinding) = begin
     expr = binding.expr
     bind = binding.bind
     name = CSTParser.has_sig(expr) ? str_value(CSTParser.get_sig(expr)) : bind.name
-    Dict(
-        :name  => name,
-        :type  => static_type(bind),
-        :icon  => static_icon(bind),
-        :lines => [first(binding.lines), last(binding.lines)]
-    )
+    OutlineItem(name, static_type(bind), static_icon(bind), binding)
 end
 outlineitem(call::ToplevelCall) = begin
     # show includes
-    isinclude(call.expr) && return Dict(
-        :name  => call.str,
-        :type  => "module",
-        :icon  => "icon-file-code",
-        :lines => [first(call.lines), last(call.lines)]
-    )
-
-    nothing
+    return if isinclude(call.expr)
+        OutlineItem(call.str, "module", "icon-file-code", call)
+    elseif isprecompile(call.expr)
+        OutlineItem(call.str, "module", "icon-file-binary", call)
+    else
+        nothing
+    end
 end
 outlineitem(macrocall::ToplevelMacroCall) = begin
     # don't show doc strings
     isdoc(macrocall.expr) && return nothing
-
     # show first line verbatim of macro calls
-    Dict(
-        :name  => strlimit(first(split(macrocall.str, '\n')), 100),
-        :type  => "snippet",
-        :icon  => "icon-mention",
-        :lines => [first(macrocall.lines), last(macrocall.lines)]
-    )
+    verbatim = strlimit(first(split(macrocall.str, '\n')), 100)
+    OutlineItem(verbatim, "snippet", "icon-mention", macrocall)
 end
 outlineitem(usage::ToplevelModuleUsage) = begin
-    Dict(
-        :name  => replace(str_value(usage.expr), ":" => ": "),
-        :type  => "mixin",
-        :icon  => "icon-package",
-        :lines => [first(usage.lines), last(usage.lines)]
-    )
+    useline = replace(str_value(usage.expr), ":" => ": ")
+    OutlineItem(useline, "mixin", "icon-package", usage)
 end

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -111,19 +111,19 @@ function str_value(x::EXPR)::String
 end
 
 """
-    str_value_as_is(expr::EXPR, text::String, pos::Int)
+    str_value_verbatim(expr::EXPR, text::String, pos::Int)
 
-_Extract_ a source code from `text` that corresponds to `expr`.
+_Extract_ a source code from `text` that corresponds to `expr` starting from `pos`.
 """
-function str_value_as_is(expr::EXPR, text::String, pos::Int)
+function str_value_verbatim(expr::EXPR, text::String, pos::Int)
     endpos = pos + expr.span
     n = ncodeunits(text)
     s = nextind(text, clamp(pos - 1, 0, n))
     e = prevind(text, clamp(endpos, 1, n + 1))
     strip(text[s:e])
 end
-str_value_as_is(bind::Binding, text::String, pos::Int) = str_value_as_is(bind.val, text, pos)
-str_value_as_is(bind, text::String, pos::Int) = ""
+str_value_verbatim(bind::Binding, text::String, pos::Int) = str_value_verbatim(bind.val, text, pos)
+str_value_verbatim(bind, text::String, pos::Int) = ""
 
 # atom icon & types
 # -----------------

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -8,6 +8,12 @@ using CSTParser: EXPR, typof, kindof, valof, parentof
 include("bindings.jl")
 include("scope.jl")
 
+# toplevel / local
+# ----------------
+
+include("toplevel.jl")
+include("local.jl")
+
 # is utilities
 # ------------
 
@@ -130,6 +136,7 @@ str_value_verbatim(bind, text::String, pos::Int) = ""
 # NOTE: need to keep this consistent with wstype/wsicon
 
 static_type(bind::Binding) = static_type(bind.val)
+static_type(bind::ActualLocalBinding) = static_type(bind.expr)
 function static_type(val::EXPR)
     if CSTParser.defines_function(val)
         "function"
@@ -148,6 +155,7 @@ function static_type(val::EXPR)
 end
 
 static_icon(bind::Binding) = static_icon(bind.val)
+static_icon(bind::ActualLocalBinding) = static_icon(bind.expr)
 function static_icon(val::EXPR)
     if CSTParser.defines_function(val)
         "λ"
@@ -164,7 +172,3 @@ function static_icon(val::EXPR)
         isconstexpr(val) ? "c" : "v"
     end
 end
-
-
-include("toplevel.jl")
-include("local.jl")

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -23,6 +23,12 @@ function isinclude(expr::EXPR)
         endswith(filename, ".jl")
 end
 
+function isprecompile(expr::EXPR)
+    iscallexpr(expr) &&
+        length(expr) >= 1 &&
+        valof(expr.args[1]) == "__precompile__"
+end
+
 function isdoc(expr::EXPR)
     ismacrocall(expr) &&
         length(expr) >= 1 &&

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -70,16 +70,16 @@ function _toplevelitems(
                 (bind = bindingof(arg)) === nothing && continue
                 push!(items, ToplevelBinding(arg, bind, lines))
             end
-        end
-
         # toplevel call
-        iscallexpr(expr) && push!(items, ToplevelCall(expr, lines, str_value_as_is(expr, text, pos)))
-
+        elseif iscallexpr(expr)
+            push!(items, ToplevelCall(expr, lines, str_value_as_is(expr, text, pos)))
         # toplevel macro call
-        ismacrocall(expr) && push!(items, ToplevelMacroCall(expr, lines, str_value_as_is(expr, text, pos)))
-
+        elseif ismacrocall(expr)
+            push!(items, ToplevelMacroCall(expr, lines, str_value_as_is(expr, text, pos)))
         # module usages
-        ismoduleusage(expr) && push!(items, ToplevelModuleUsage(expr, lines))
+        elseif ismoduleusage(expr)
+            push!(items, ToplevelModuleUsage(expr, lines))
+        end
     end
 
     # look for more toplevel items in expr:

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -16,13 +16,13 @@ end
 struct ToplevelCall <: ToplevelItem
     expr::EXPR
     lines::UnitRange{Int}
-    str::String
+    verbatim::String
 end
 
 struct ToplevelMacroCall <: ToplevelItem
     expr::EXPR
     lines::UnitRange{Int}
-    str::String
+    verbatim::String
 end
 
 struct ToplevelModuleUsage <: ToplevelItem
@@ -72,10 +72,10 @@ function _toplevelitems(
             end
         # toplevel call
         elseif iscallexpr(expr)
-            push!(items, ToplevelCall(expr, lines, str_value_as_is(expr, text, pos)))
+            push!(items, ToplevelCall(expr, lines, str_value_verbatim(expr, text, pos)))
         # toplevel macro call
         elseif ismacrocall(expr)
-            push!(items, ToplevelMacroCall(expr, lines, str_value_as_is(expr, text, pos)))
+            push!(items, ToplevelMacroCall(expr, lines, str_value_verbatim(expr, text, pos)))
         # module usages
         elseif ismoduleusage(expr)
             push!(items, ToplevelModuleUsage(expr, lines))

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -41,12 +41,13 @@ keyword arguments:
     other than `mod`, otherwise enter into every module.
 - `inmod::Bool`: if `true`, don't include toplevel items until it enters into `mod`.
 """
-toplevelitems(text::String; kwargs...) = toplevelitems(text, CSTParser.parse(text, true); kwargs...)
-function toplevelitems(text::String, expr::EXPR; kwargs...)
+toplevelitems(text::String; kwargs...)::Vector{ToplevelItem} =
+    toplevelitems(text, CSTParser.parse(text, true); kwargs...)
+function toplevelitems(text::String, expr::EXPR; kwargs...)::Vector{ToplevelItem}
     traverse_expr!(expr)
     return _toplevelitems(text, expr; kwargs...)
 end
-toplevelitems(text::String, expr::Nothing; kwargs...) = ToplevelItem[]
+toplevelitems(text::String, expr::Nothing; kwargs...)::Vector{ToplevelItem} = ToplevelItem[]
 
 function _toplevelitems(
     text::String, expr::EXPR,

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -153,8 +153,8 @@
 
             ## escape recursive `include` loop
             let
-                @test (Atom.__collecttoplevelitems(nothing, joinpath′(fixturedir, "self_recur.jl"); inmod = true); true)
-                @test (Atom.__collecttoplevelitems(nothing, joinpath′(fixturedir, "mutual_recur.jl"); inmod = true); true)
+                @test (Atom._collecttoplevelitems_static(nothing, joinpath′(fixturedir, "self_recur.jl"); inmod = true); true)
+                @test (Atom._collecttoplevelitems_static(nothing, joinpath′(fixturedir, "mutual_recur.jl"); inmod = true); true)
             end
 
             ## don't include bindings outside of a module

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -243,10 +243,23 @@
         @testset "regenerating toplevel symbols" begin
             regeneratesymbols()
 
+            # cache symbols in loaded modules
             @test haskey(SYMBOLSCACHE, "Base")
             @test length(keys(SYMBOLSCACHE["Base"])) > 100
-            @test haskey(SYMBOLSCACHE, "Example") # cache symbols even if not loaded
-            @test toplevelgotoitems("hello", Example, "", nothing) |> !isempty
+            @test haskey(SYMBOLSCACHE, "Atom")
+            @test length(keys(SYMBOLSCACHE["Atom"])) === length(atommodfiles)
+
+            # cache symbols even if not loaded
+            # FIXME:
+            # `Pkg.dependencies()` doesn't include dependencies in `extra` section.
+            # Let's skip this case until we find a way to make `Pkg.dependencies()` aware of them.
+            @test_skip haskey(SYMBOLSCACHE, "Example")
+
+            @testset "goto for unloaded packages" begin
+                using Atom: globalgotoitems_unloaded
+
+                @test !isempty(globalgotoitems_unloaded("hello", "Example"))
+            end
         end
 
         @testset "clear toplevel symbols" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Atom, Test, JSON, Logging, CSTParser, Example
+using Atom, Test, JSON, Logging, CSTParser
 
 
 joinpath′(files...) = Atom.fullpath(joinpath(files...))

--- a/test/static/local.jl
+++ b/test/static/local.jl
@@ -1,3 +1,6 @@
+name_and_root(b::Atom.ActualLocalBinding) = (b.name, b.root)
+name(b::Atom.ActualLocalBinding) = b.name
+
 let str = """
     function local_bindings(expr, bindings = [], pos = 1)
         bind = CSTParser.bindingof(expr)
@@ -37,7 +40,7 @@ let str = """
         return bindings
     end
     """
-    let ls = Set(map(x -> (x[:name], x[:root]), Atom.locals(str, 15, 1)))
+    let ls = Set(name_and_root.(Atom.locals(str, 15, 1)))
         for l in [
                 ("i", "")
                 ("arg", "")
@@ -54,7 +57,7 @@ let str = """
         end
     end
 
-    let ls = Set(map(x -> (x[:name], x[:root]), Atom.locals(str, 21, 100)))
+    let ls = Set(name_and_root.(Atom.locals(str, 21, 100)))
         for l in [
                 ("localbindings", "local_bindings")
                 ("pos", "local_bindings")
@@ -85,22 +88,22 @@ let str = """
     end
     """
     outers = (("bar", ""), ("f", ""), ("foo", ""))
-    let ls = Set(map(x -> (x[:name], x[:root]), Atom.locals(str, 1, 1)))
+    let ls = Set(name_and_root.(Atom.locals(str, 1, 1)))
         for o in outers; @test o in ls; end
     end
-    let ls = Set(map(x -> (x[:name], x[:root]), Atom.locals(str, 2, 1)))
+    let ls = Set(name_and_root.(Atom.locals(str, 2, 1)))
         for o in outers; @test o in ls; end
         @test ("x", "f") in ls
         @test ("ff", "f") in ls
     end
-    let ls = Set(map(x -> (x[:name], x[:root]), Atom.locals(str, 4, 100)))
+    let ls = Set(name_and_root.(Atom.locals(str, 4, 100)))
         for o in outers; @test o in ls; end
         @test ("ff", "f") in ls
         @test ("x", "") in ls
         @test ("xxx", "") in ls
         @test ("z", "") in ls
     end
-    let ls = Set(map(x -> (x[:name], x[:root]), Atom.locals(str, 10, 100)))
+    let ls = Set(name_and_root.(Atom.locals(str, 10, 100)))
         for o in outers; @test o in ls; end
         @test ("x", "foo") in ls
         @test ("asd", "foo") in ls
@@ -117,16 +120,16 @@ let str = """
 
     ls = Atom.locals(str, 1, 1)
     # basic
-    for l in filter(l -> l[:line] == 2, ls)
-        @test l[:name] in ("tpl1", "tpl2")
-        @test l[:root] == "foo"
-        @test l[:verbatim] == "tpl1, tpl2 = (1, 2)"
+    for l in filter(l -> l.line == 2, ls)
+        @test l.name in ("tpl1", "tpl2")
+        @test l.root == "foo"
+        @test l.verbatim == "tpl1, tpl2 = (1, 2)"
     end
     # named tuple elements shouldn't show up in completions
-    for l in filter(l -> l[:line] == 3, ls)
-        @test l[:name] in ("shown1", "shown2")
-        @test l[:root] == "foo"
-        @test l[:verbatim] == "shown1, shown2 = (ntpl1 = 1, ntpl2 = 2)"
+    for l in filter(l -> l.line == 3, ls)
+        @test l.name in ("shown1", "shown2")
+        @test l.root == "foo"
+        @test l.verbatim == "shown1, shown2 = (ntpl1 = 1, ntpl2 = 2)"
     end
 end
 
@@ -138,7 +141,7 @@ let str = """
     end
     """
 
-    binds = map(l -> l[:name], Atom.locals(str, 1, 0))
+    binds = name.(Atom.locals(str, 1, 0))
     @test "ary" in binds
     @test "item" in binds
     @test "T" in binds
@@ -158,7 +161,7 @@ let str = """
     end
     """
 
-    binds = map(l -> l[:name], Atom.locals(str, 2, 4))
+    binds = name.(Atom.locals(str, 2, 4))
     @test "ary" in binds
     @test "i" in binds
     @test "T" in binds
@@ -174,7 +177,7 @@ let str = """
         return 12
     end
     """
-    let ls = Set(map(x -> (x[:name], x[:root]), Atom.locals(str, 2, 1)))
+    let ls = Set(name_and_root.(Atom.locals(str, 2, 1)))
         for l in [
                 ("foo", "")
                 ("xxx", "foo")
@@ -183,7 +186,7 @@ let str = """
             @test l in ls
         end
     end
-    let ls = Set(map(x -> (x[:name], x[:root]), Atom.locals(str, 3, 1)))
+    let ls = Set(name_and_root.(Atom.locals(str, 3, 1)))
         for l in [
                 ("foo", "")
                 ("xxx", "foo")
@@ -193,7 +196,7 @@ let str = """
             @test l in ls
         end
     end
-    let ls = Set(map(x -> (x[:name], x[:root]), Atom.locals(str, 5, 1)))
+    let ls = Set(name_and_root.(Atom.locals(str, 5, 1)))
         for l in [
                 ("foo", "")
                 ("xxx", "foo")

--- a/test/static/local.jl
+++ b/test/static/local.jl
@@ -120,13 +120,13 @@ let str = """
     for l in filter(l -> l[:line] == 2, ls)
         @test l[:name] in ("tpl1", "tpl2")
         @test l[:root] == "foo"
-        @test l[:bindstr] == "tpl1, tpl2 = (1, 2)"
+        @test l[:verbatim] == "tpl1, tpl2 = (1, 2)"
     end
     # named tuple elements shouldn't show up in completions
     for l in filter(l -> l[:line] == 3, ls)
         @test l[:name] in ("shown1", "shown2")
         @test l[:root] == "foo"
-        @test l[:bindstr] == "shown1, shown2 = (ntpl1 = 1, ntpl2 = 2)"
+        @test l[:verbatim] == "shown1, shown2 = (ntpl1 = 1, ntpl2 = 2)"
     end
 end
 


### PR DESCRIPTION
general:
- more preferable naming

goto:
- recover goto for unloaded packages (can be invoked via docpane)

outline:
- introduce `ActualLocalBinding` struct
- minimum condition check for `toplevelitems`
- show `__precompile__` calls in outline

Needs https://github.com/JunoLab/atom-julia-client/pull/681