### PR TITLE
moar return types:

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -132,12 +132,14 @@ function completionreturntype(c::REPLCompletions.MethodCompletion)
   # so here we eagerly respect that if inference succeeded
   f = c.func
   tt = Base.tuple_type_tail(c.input_types)
-  inf = try
-    Core.Compiler.return_type(f, tt, world)
-  catch err
-    nothing
+  if !isempty(tt.parameters)
+    inf = try
+      Core.Compiler.return_type(f, tt, world)
+    catch err
+      nothing
+    end
+    inf ∉ (nothing, Any, Union{}) && return shortstr(inf)
   end
-  inf ∉ (nothing, Any, Union{}) && return shortstr(inf)
 
   # sometimes method signature can tell the return type by itself
   m = c.method

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -123,6 +123,7 @@ completionreturntype(::REPLCompletions.PathCompletion) = "Path"
 
 using JuliaInterpreter: sparam_syms
 
+# TODO: lazy return type inference
 function completionreturntype(c::REPLCompletions.MethodCompletion)
   try
     world = typemax(UInt) # world age


### PR DESCRIPTION
- Show return types for all the method completions
  * revert back some part that was introduced in #234 
  * I found revealing a return type on selection is not natural since all the `leftLabel` of suggestions are visible
  * first time method completion invocation is reverted back to be slow, though.
- Now return types can be inferred from input types, while we only used method signature in the previous implementation. Now we can infer return type for more completion cases.
  * E.g.: If we have `f(a) = a`, within the previous behaviour we can't infer in any completion case. With this PR we can show return types if there is input arguments:
    + `f(1|` => inferred as `Int`
    + `f('1'|` => inferred as `Char`