### PR TITLE
fix hide prompt issues

### DIFF
--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -15,6 +15,8 @@ function __init__()
     fixdisplayorder()
   end
 
+  atreplinit(instantiate_repl_keybindings)
+
   Atom.handle("connected") do
     if isREPL(before_run_repl = true)
       reset_repl_history()


### PR DESCRIPTION
- no spurious error when hideprompt is called before we have registered 
our own on_done handler
- keep zero-width spaces out of repl history

Fixes https://github.com/JunoLab/Juno.jl/issues/487.