### PR TITLE
lazy Traceur loading

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,6 @@ Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
-Traceur = "37b6cedf-1f77-55f8-9503-c64b63398394"
 TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 WebSockets = "104b5d7c-a370-577a-8038-80a2059c5097"
@@ -60,6 +59,7 @@ julia = "0.7, 1"
 [extras]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Traceur = "37b6cedf-1f77-55f8-9503-c64b63398394"
 
 [targets]
 test = ["Example", "Test"]

--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -4,8 +4,7 @@ __precompile__()
 module Atom
 
 using Base.StackTraces, InteractiveUtils, Logging
-using Juno, Lazy, JSON, MacroTools, Media
-import Requires
+using Juno, Lazy, JSON, MacroTools, Media, Requires
 import Media: @dynamic
 
 function __init__()
@@ -38,9 +37,8 @@ function __init__()
     nothing
   end
 
-  Requires.@require WebIO="0f1e0344-ec1d-5b48-a673-e5cf874b6c29" begin
-    include("display/webio.jl")
-  end
+  @require WebIO="0f1e0344-ec1d-5b48-a673-e5cf874b6c29" include("display/webio.jl")
+  @require Traceur="37b6cedf-1f77-55f8-9503-c64b63398394" include("profiler/traceur.jl")
 end
 
 # basics
@@ -64,7 +62,6 @@ include("formatter.jl")
 include("frontend.jl")
 include("debugger/debugger.jl")
 include("profiler/profiler.jl")
-include("profiler/traceur.jl")
 
 include("precompile.jl")
 _precompile_()

--- a/src/profiler/traceur.jl
+++ b/src/profiler/traceur.jl
@@ -1,4 +1,4 @@
-import Traceur
+import .Traceur
 
 function trace(ex, args...)
     :($(showtrace)($(gettrace)(() -> $(esc(ex)); $(map(esc, args)...))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,12 @@ atomjldir = joinpath′(@__DIR__, "..")
 atomsrcdir = joinpath′(atomjldir, "src")
 atomjlfile = joinpath′(atomsrcdir, "Atom.jl")
 webiofile = joinpath′(atomsrcdir, "display", "webio.jl")
+traceurfile = joinpath′(atomsrcdir, "profiler", "traceur.jl")
 
-# files in `Atom` module (except files in its submodules)
+# files in `Atom` module except files in submodules
+# TODO:
+# currently both Revise-like and CSTPraser-based module traverse fails
+# to detect lazily loaded files even if they are actually loaded.
 atommodfiles = let
     files = []
     debuggerdir = joinpath′(atomsrcdir, "debugger")
@@ -23,15 +27,12 @@ atommodfiles = let
         end
         if d == profilerdir
             push!(files, joinpath′(d, "profiler.jl"))
-            push!(files, joinpath′(d, "traceur.jl"))
+            # push!(files, joinpath′(d, "traceur.jl"))
             continue
         end
 
         for f in fs
-            # NOTE: currently both Revise-like and CSTPraser-based approach fails
-            # to detect display/webio.jl as a file in Atom module
             f == "webio.jl" && continue
-
             # .jl check is needed for travis, who creates hoge.cov files
             endswith(f, ".jl") && push!(files, joinpath′(d, f))
         end


### PR DESCRIPTION
Since Traceur is still in alpha (and currently has problems in its performance and robustness), I believe ppl don't use this integration so much that it might be okay that it's not provided by default.
Although Traceur (and Cassette) dependency isn't so heavy, but will improve the loading time for sure.