### PR TITLE
internal refactors

### DIFF
--- a/src/goto.jl
+++ b/src/goto.jl
@@ -48,18 +48,16 @@ function gotosymbol(
   return (error = true,) # nothing hits
 end
 
-const GotoItem = let
-  n2t = (
-    (:name, String),
-    (:text, String),
-    (:file, String),
-    (:line, Int)
-  )
-  NamedTuple{tuple(first.(n2t)...), Tuple{last.(n2t)...}}
+struct GotoItem
+  name::String
+  text::String
+  file::String
+  line::Int
+  GotoItem(name, text, file::String, line) =
+    new(name, text, normpath(file), line)
 end
-GotoItem(name::String, text::String, file::String, line::Int = 0)::GotoItem =
-  (name = name, text = text, file = normpath(file), line = line)
-GotoItem(name::String, file::String, line::Int = 0) = GotoItem(name, name, file, line)
+
+GotoItem(name, file, line = 0) = GotoItem(name, name, file, line)
 
 ### local goto
 
@@ -244,8 +242,8 @@ function _collecttoplevelitems_static(mod::Union{Nothing, String}, entrypath::St
   return pathitemsmap
 end
 
-GotoItem(path::String, item::ToplevelItem) = GotoItem("", path) # fallback case
-function GotoItem(path::String, binding::ToplevelBinding)
+GotoItem(path, item::ToplevelItem) = GotoItem("", path) # fallback case
+function GotoItem(path, binding::ToplevelBinding)
   expr = binding.expr
   bind = binding.bind
   name = CSTParser.defines_macro(expr) ? string('@', bind.name) : bind.name

--- a/src/goto.jl
+++ b/src/goto.jl
@@ -12,7 +12,7 @@ handle("gotosymbol") do data
     mod || "Main",
     text || "",
   ] = data
-  gotosymbol(
+  return gotosymbol(
     word, path,
     column, row, startRow, context, onlyGlobal,
     mod, text,
@@ -30,10 +30,7 @@ function gotosymbol(
     # local goto
     if !onlyglobal
       localitems = localgotoitem(word, path, column, row, startrow, context)
-      isempty(localitems) || return Dict(
-        :error => false,
-        :items => todict.(localitems)
-      )
+      isempty(localitems) || return (error = false, items = localitems)
     end
 
     # global goto
@@ -43,35 +40,26 @@ function gotosymbol(
     else
       globalgotoitems(word, m, path, text)
     end
-    isempty(globalitems) || return Dict(
-      :error => false,
-      :items => todict.(globalitems),
-    )
+    isempty(globalitems) || return (error = false, items = globalitems)
   catch err
-    return Dict(:error => true)
+    return (error = true,)
   end
 
-  return Dict(:error => true) # nothing hits
+  return (error = true,) # nothing hits
 end
 
-struct GotoItem
-  name::String
-  text::String
-  file::String
-  line::Int
-
-  GotoItem(name::String, text::String, file::String, line::Int = 0) =
-    new(name, text, normpath(file), line)
+const GotoItem = let
+  n2t = (
+    (:name, String),
+    (:text, String),
+    (:file, String),
+    (:line, Int)
+  )
+  NamedTuple{tuple(first.(n2t)...), Tuple{last.(n2t)...}}
 end
+GotoItem(name::String, text::String, file::String, line::Int = 0)::GotoItem =
+  (name = name, text = text, file = normpath(file), line = line)
 GotoItem(name::String, file::String, line::Int = 0) = GotoItem(name, name, file, line)
-
-# for messaging over julia ⟷ Atom
-todict(gotoitem::GotoItem) = Dict(
-  :text      => gotoitem.text,
-  :file      => gotoitem.file,
-  :line      => gotoitem.line,
-  :secondary => string(gotoitem.file, ':', gotoitem.line + 1),
-)
 
 ### local goto
 

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -9,7 +9,7 @@ handle("updateeditor") do data
     return try
         updateeditor(text, mod, path, updateSymbols)
     catch err
-        []
+        OutlineItem[]
     end
 end
 
@@ -23,8 +23,15 @@ function updateeditor(text, mod = "Main", path = nothing, updateSymbols = true)
     outline(toplevelitems(text))
 end
 
+struct OutlineItem
+    name::String
+    type::String
+    icon::String
+    start::Int
+    stop::Int
+end
 OutlineItem(name, type, icon, item::ToplevelItem) =
-    (name = name, type = type, icon = icon, start = first(item.lines), stop = last(item.lines))
+    OutlineItem(name, type, icon, first(item.lines), last(item.lines))
 
 outline(items) = filter!(item -> item !== nothing, outlineitem.(items))
 

--- a/src/outline.jl
+++ b/src/outline.jl
@@ -7,7 +7,7 @@ handle("updateeditor") do data
     ] = data
 
     return try
-        todict.(updateeditor(text, mod, path, updateSymbols))
+        updateeditor(text, mod, path, updateSymbols)
     catch err
         []
     end
@@ -23,26 +23,10 @@ function updateeditor(text, mod = "Main", path = nothing, updateSymbols = true)
     outline(toplevelitems(text))
 end
 
-struct OutlineItem
-    name::String
-    type::String
-    icon::String
-    start::Int
-    stop::Int
-end
 OutlineItem(name, type, icon, item::ToplevelItem) =
-    OutlineItem(name, type, icon, first(item.lines), last(item.lines))
+    (name = name, type = type, icon = icon, start = first(item.lines), stop = last(item.lines))
 
-# for messaging over julia ⟷ Atom
-todict(item::OutlineItem) = Dict(
-    :name  => item.name,
-    :type  => item.type,
-    :icon  => item.icon,
-    :start => item.start,
-    :stop  => item.stop
-)
-
-outline(items)::Vector{OutlineItem} = filter!(item -> item !== nothing, outlineitem.(items))
+outline(items) = filter!(item -> item !== nothing, outlineitem.(items))
 
 outlineitem(item::ToplevelItem) = nothing # fallback case
 outlineitem(binding::ToplevelBinding) = begin

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -64,13 +64,13 @@ function _precompile_()
     try; isdefined(Atom, Symbol("#214#219")) && precompile(Tuple{getfield(Atom, Symbol("#214#219"))}); catch err; @debug err; end
     try; isdefined(Atom, Symbol("#222#223")) && precompile(Tuple{getfield(Atom, Symbol("#222#223")),Base.MethodList}); catch err; @debug err; end
     try; isdefined(Atom, Symbol("#222#223")) && precompile(Tuple{getfield(Atom, Symbol("#222#223")),MD}); catch err; @debug err; end
-    try; isdefined(Atom, Symbol("#276#278")) && precompile(Tuple{getfield(Atom, Symbol("#276#278")),FuzzyCompletions.DictCompletion}); catch err; @debug err; end
-    try; isdefined(Atom, Symbol("#276#278")) && precompile(Tuple{getfield(Atom, Symbol("#276#278")),FuzzyCompletions.FieldCompletion}); catch err; @debug err; end
-    try; isdefined(Atom, Symbol("#276#278")) && precompile(Tuple{getfield(Atom, Symbol("#276#278")),FuzzyCompletions.KeywordCompletion}); catch err; @debug err; end
-    try; isdefined(Atom, Symbol("#276#278")) && precompile(Tuple{getfield(Atom, Symbol("#276#278")),FuzzyCompletions.MethodCompletion}); catch err; @debug err; end
-    try; isdefined(Atom, Symbol("#276#278")) && precompile(Tuple{getfield(Atom, Symbol("#276#278")),FuzzyCompletions.ModuleCompletion}); catch err; @debug err; end
-    try; isdefined(Atom, Symbol("#276#278")) && precompile(Tuple{getfield(Atom, Symbol("#276#278")),FuzzyCompletions.PathCompletion}); catch err; @debug err; end
-    try; isdefined(Atom, Symbol("#276#278")) && precompile(Tuple{getfield(Atom, Symbol("#276#278")),FuzzyCompletions.PropertyCompletion}); catch err; @debug err; end
+    try; isdefined(Atom, Symbol("#277#279")) && precompile(Tuple{getfield(Atom, Symbol("#277#279")),FuzzyCompletions.DictCompletion}); catch err; @debug err; end
+    try; isdefined(Atom, Symbol("#277#279")) && precompile(Tuple{getfield(Atom, Symbol("#277#279")),FuzzyCompletions.FieldCompletion}); catch err; @debug err; end
+    try; isdefined(Atom, Symbol("#277#279")) && precompile(Tuple{getfield(Atom, Symbol("#277#279")),FuzzyCompletions.KeywordCompletion}); catch err; @debug err; end
+    try; isdefined(Atom, Symbol("#277#279")) && precompile(Tuple{getfield(Atom, Symbol("#277#279")),FuzzyCompletions.MethodCompletion}); catch err; @debug err; end
+    try; isdefined(Atom, Symbol("#277#279")) && precompile(Tuple{getfield(Atom, Symbol("#277#279")),FuzzyCompletions.ModuleCompletion}); catch err; @debug err; end
+    try; isdefined(Atom, Symbol("#277#279")) && precompile(Tuple{getfield(Atom, Symbol("#277#279")),FuzzyCompletions.PathCompletion}); catch err; @debug err; end
+    try; isdefined(Atom, Symbol("#277#279")) && precompile(Tuple{getfield(Atom, Symbol("#277#279")),FuzzyCompletions.PropertyCompletion}); catch err; @debug err; end
     try; isdefined(Atom, Symbol("#33#34")) && precompile(Tuple{getfield(Atom, Symbol("#33#34"))}); catch err; @debug err; end
     try; isdefined(Atom, Symbol("#37#38")) && precompile(Tuple{getfield(Atom, Symbol("#37#38")),String}); catch err; @debug err; end
     try; isdefined(Atom, Symbol("#39#41")) && precompile(Tuple{getfield(Atom, Symbol("#39#41")),String}); catch err; @debug err; end
@@ -80,20 +80,15 @@ function _precompile_()
             precompile(fbody, (String,String,typeof(Atom.fixpath),String,))
         end
     end); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Core.kwftype(typeof(Atom.Type)),NamedTuple{(:rl, :ll, :url, :detail),NTuple{4,String}},Type{NamedTuple{(:replacementPrefix, :text, :type, :icon, :rightLabel, :leftLabel, :description, :descriptionMoreURL, :detailtype),NTuple{9,String}}},String,String,String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Core.kwftype(typeof(Atom._collecttoplevelitems_static)),NamedTuple{(:inmod,),Tuple{Bool}},typeof(Atom._collecttoplevelitems_static),Nothing,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Core.kwftype(typeof(Atom.modulefiles)),NamedTuple{(:inmod,),Tuple{Bool}},typeof(modulefiles),String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Core.kwftype(typeof(Atom.toplevelitems)),NamedTuple{(:mod, :inmod),Tuple{String,Bool}},typeof(toplevelitems),String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Type{Atom.EvalError},StackOverflowError,Array{Base.StackTraces.StackFrame,1}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{Atom.GotoItem},String,Atom.ToplevelCall})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{Atom.GotoItem},String,Atom.ToplevelMacroCall})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{Atom.GotoItem},String,Atom.ToplevelModuleUsage})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Type{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Axes,F,Args} where Args<:Tuple where F where Axes},typeof(Atom.localdatatip),Tuple{Array{Atom.ActualLocalBinding,1},Base.RefValue{SubString{String}},Int64}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Axes,F,Args} where Args<:Tuple where F where Axes},typeof(todict),Tuple{Array{Atom.GotoItem,1}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Axes,F,Args} where Args<:Tuple where F where Axes},typeof(todict),Tuple{Array{OutlineItem,1}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Axes,F,Args} where Args<:Tuple where F where Axes},typeof(|>),Tuple{Array{Atom.GotoItem,1},Base.RefValue{typeof(todict)}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{Base.RefValue},typeof(todict)})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{Set},Array{OutlineItem,1}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(==),Array{Atom.GotoItem,1},Array{Any,1}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Type{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}}},String,Atom.ToplevelCall})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Type{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}}},String,Atom.ToplevelMacroCall})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Type{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}}},String,Atom.ToplevelModuleUsage})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.appendline),String,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.completion),Module,FuzzyCompletions.DictCompletion,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.completion),Module,FuzzyCompletions.FieldCompletion,String})); catch err; @debug err; end
@@ -106,6 +101,7 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(Atom.completion),Module,REPL.REPLCompletions.ModuleCompletion,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.completion),Module,REPL.REPLCompletions.PathCompletion,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.completion),Module,REPL.REPLCompletions.PropertyCompletion,String})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Atom.completiondetail!),Dict{String,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.displayandrender),Module})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.displayandrender),Symbol})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.docs),String})); catch err; @debug err; end
@@ -121,6 +117,7 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(Atom.handlemsg),Dict{String,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.isactive),Base.GenericIOBuffer{Array{UInt8,1}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.isanon),Function})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Atom.localgotoitem),String,Nothing,Int64,Int64,Int64,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.md_hlines),MD})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.msg),String,Int64,Vararg{Any,N} where N})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.pkgpath),String})); catch err; @debug err; end
@@ -166,7 +163,7 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{Method,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{String,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{String,Array{String,1}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{String,Dict{String,Array{Atom.GotoItem,1}}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{String,Dict{String,Array{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}},1}}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,ErrorException})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Float16})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Float32})); catch err; @debug err; end
@@ -188,25 +185,12 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(Atom.wstype),Module,Symbol,Type{T} where T})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.broadcasted),Function,Array{Atom.ActualLocalBinding,1},SubString{String},Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.broadcasted),Function,Array{Atom.ActualLocalBinding,1}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.broadcasted),Function,Array{Atom.GotoItem,1},Function})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.broadcasted),Function,Array{Atom.GotoItem,1}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.broadcasted),Function,Array{OutlineItem,1}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.combine_styles),Array{Atom.GotoItem,1},Base.RefValue{typeof(todict)}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{Dict{Symbol,Any},1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.localdatatip),Tuple{Base.Broadcast.Extruded{Array{Atom.ActualLocalBinding,1},Tuple{Bool},Tuple{Int64}},Base.RefValue{SubString{String}},Int64}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{Dict{Symbol,Any},1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(todict),Tuple{Base.Broadcast.Extruded{Array{Atom.GotoItem,1},Tuple{Bool},Tuple{Int64}}}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{Dict{Symbol,Any},1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(todict),Tuple{Base.Broadcast.Extruded{Array{OutlineItem,1},Tuple{Bool},Tuple{Int64}}}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{Dict{Symbol,Any},1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(|>),Tuple{Base.Broadcast.Extruded{Array{Atom.GotoItem,1},Tuple{Bool},Tuple{Int64}},Base.RefValue{typeof(todict)}}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{Int64,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.localdatatip),Tuple{Base.Broadcast.Extruded{Array{Atom.ActualLocalBinding,1},Tuple{Bool},Tuple{Int64}},Base.RefValue{SubString{String}},Int64}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{NamedTuple{(:name, :type, :icon, :start, :stop),Tuple{String,String,String,Int64,Int64}},1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{Nothing,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{OutlineItem,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.materialize),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Nothing,typeof(Atom.localdatatip),Tuple{Array{Atom.ActualLocalBinding,1},Base.RefValue{SubString{String}},Int64}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.materialize),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Nothing,typeof(todict),Tuple{Array{Atom.GotoItem,1}}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.materialize),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Nothing,typeof(todict),Tuple{Array{OutlineItem,1}}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.materialize),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Nothing,typeof(|>),Tuple{Array{Atom.GotoItem,1},Base.RefValue{typeof(todict)}}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.restart_copyto_nonleaf!),Array{Union{Nothing, OutlineItem},1},Array{Nothing,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},OutlineItem,Int64,Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base._promote_typejoin),Type{Nothing},Type{OutlineItem}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.allocatedinline),Type{Atom.GotoItem}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.allocatedinline),Type{Dict{String,Array{Atom.GotoItem,1}}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Base.Broadcast.restart_copyto_nonleaf!),Array{Union{Nothing, NamedTuple{(:name, :type, :icon, :start, :stop),Tuple{String,String,String,Int64,Int64}}},1},Array{Nothing,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},NamedTuple{(:name, :type, :icon, :start, :stop),Tuple{String,String,String,Int64,Int64}},Int64,Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.collect_to!),Array{Any,1},Base.Generator{Array{Any,1},typeof(Atom.renderMDinline)},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.collect_to!),Array{Hiccup.Node,1},Base.Generator{Array{Any,1},typeof(Atom.renderMD)},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.collect_to_with_first!),Array{Dict{Symbol,Any},1},Dict{Symbol,Any},Base.Generator{Array{DocSeeker.DocObj,1},typeof(Atom.renderitem)},Int64})); catch err; @debug err; end
@@ -247,11 +231,7 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(Media.render),Juno.Inline,Text{String}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Media.render),Juno.Inline,Type{T} where T})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(clearsymbols)})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(convert),Type{Array{OutlineItem,1}},Array{Nothing,1}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(convert),Type{Array{OutlineItem,1}},Array{OutlineItem,1}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(convert),Type{Array{OutlineItem,1}},Array{Union{Nothing, OutlineItem},1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(convert),Type{Union{Nothing, Atom.Binding}},Atom.Binding})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(delete!),Dict{String,Dict{String,Array{Atom.GotoItem,1}}},String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getdocs),Module,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getfield′),Any,String,Atom.Undefined})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getfield′),Any,String})); catch err; @debug err; end
@@ -260,12 +240,10 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(getfield′),Module,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getfield′),Module,Symbol,Function})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getfield′),Module,Symbol})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(getindex),Dict{String,Array{Atom.GotoItem,1}},String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(globaldatatip),String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(globalgotoitems),String,Module,Nothing,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(globalgotoitems),String,Module,String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(globalgotoitems_unloaded),String,String})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(in),OutlineItem,Set{OutlineItem}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isempty),Array{Atom.ToplevelItem,1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(ismacro),Function})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(ismacro),String})); catch err; @debug err; end
@@ -278,7 +256,7 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(isundefined),Dict{Method,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Dict{String,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Dict{String,Array{String,1}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(isundefined),Dict{String,Dict{String,Array{Atom.GotoItem,1}}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(isundefined),Dict{String,Dict{String,Array{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}},1}}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Function})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),HTML{String}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Int64})); catch err; @debug err; end
@@ -287,11 +265,6 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(isundefined),Regex})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Type{T} where T})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(length),Base.KeySet{String,Dict{String,Array{Atom.GotoItem,1}}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(length),Base.KeySet{String,Dict{String,Dict{String,Array{Atom.GotoItem,1}}}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(length),Dict{String,Array{Atom.GotoItem,1}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(map),Function,Array{Atom.GotoItem,1}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(map),Function,Array{OutlineItem,1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(moduledefinition),Module})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(modulefiles),Module})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(modulefiles),String,String})); catch err; @debug err; end
@@ -299,20 +272,15 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(searchcodeblocks),MD})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(searchdocs′),String,Bool,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(searchdocs′),String})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(setindex!),Array{OutlineItem,1},OutlineItem,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.localdatatip),Tuple{Base.Broadcast.Extruded{Array{Atom.ActualLocalBinding,1},Tuple{Bool},Tuple{Int64}},Base.RefValue{SubString{String}},Int64}},Type{Dict{Symbol,Any}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Type{NamedTuple{(:name, :type, :icon, :start, :stop),Tuple{String,String,String,Int64,Int64}}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Type{Nothing}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Type{OutlineItem}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(todict),Tuple{Base.Broadcast.Extruded{Array{Atom.GotoItem,1},Tuple{Bool},Tuple{Int64}}}},Type{Dict{Symbol,Any}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(todict),Tuple{Base.Broadcast.Extruded{Array{OutlineItem,1},Tuple{Bool},Tuple{Int64}}}},Type{Dict{Symbol,Any}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(|>),Tuple{Base.Broadcast.Extruded{Array{Atom.GotoItem,1},Tuple{Bool},Tuple{Int64}},Base.RefValue{typeof(todict)}}},Type{Dict{Symbol,Any}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(sprint),Function,Base.Generator{CSTParser.EXPR,typeof(Atom.str_value)}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(strlimit),String,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(toplevelitems),String})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(updatesymbols),String,Nothing,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(updatesymbols),String,String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(use_compiled_modules)})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(vcat),OutlineItem,OutlineItem,OutlineItem,Vararg{OutlineItem,N} where N})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(workspace),String})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(|>),Array{Atom.GotoItem,1},typeof(isempty)})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(|>),Array{Atom.ToplevelItem,1},typeof(length)})); catch err; @debug err; end
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -75,20 +75,22 @@ function _precompile_()
     try; isdefined(Atom, Symbol("#37#38")) && precompile(Tuple{getfield(Atom, Symbol("#37#38")),String}); catch err; @debug err; end
     try; isdefined(Atom, Symbol("#39#41")) && precompile(Tuple{getfield(Atom, Symbol("#39#41")),String}); catch err; @debug err; end
     try; isdefined(Atom, Symbol("#55#56")) && precompile(Tuple{getfield(Atom, Symbol("#55#56")),String}); catch err; @debug err; end
-    try; @assert(let fbody = try __lookup_kwbody__(which(Atom.fixpath, (String,))) catch missing end
+    try; @assert(let fbody = try __lookup_kwbody__(which(sprint, (Function,Atom.CompletionSuggestion,))) catch missing end
         if !ismissing(fbody)
-            precompile(fbody, (String,String,typeof(Atom.fixpath),String,))
+            precompile(fbody, (Nothing,Int64,typeof(sprint),Function,Atom.CompletionSuggestion,))
         end
     end); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Core.kwftype(typeof(Atom.Type)),NamedTuple{(:rl, :ll, :url, :detail),NTuple{4,String}},Type{NamedTuple{(:replacementPrefix, :text, :type, :icon, :rightLabel, :leftLabel, :description, :descriptionMoreURL, :detailtype),NTuple{9,String}}},String,String,String,String})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Core.kwftype(typeof(Atom.Type)),NamedTuple{(:rl, :ll, :url, :detail),NTuple{4,String}},Type{Atom.CompletionSuggestion},String,String,String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Core.kwftype(typeof(Atom._collecttoplevelitems_static)),NamedTuple{(:inmod,),Tuple{Bool}},typeof(Atom._collecttoplevelitems_static),Nothing,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Core.kwftype(typeof(Atom.modulefiles)),NamedTuple{(:inmod,),Tuple{Bool}},typeof(modulefiles),String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Core.kwftype(typeof(Atom.toplevelitems)),NamedTuple{(:mod, :inmod),Tuple{String,Bool}},typeof(toplevelitems),String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Type{Atom.EvalError},StackOverflowError,Array{Base.StackTraces.StackFrame,1}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Type{Atom.GotoItem},String,Atom.ToplevelCall})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Type{Atom.GotoItem},String,Atom.ToplevelMacroCall})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Type{Atom.GotoItem},String,Atom.ToplevelModuleUsage})); catch err; @debug err; end
     try; @assert(precompile(Tuple{Type{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Axes,F,Args} where Args<:Tuple where F where Axes},typeof(Atom.localdatatip),Tuple{Array{Atom.ActualLocalBinding,1},Base.RefValue{SubString{String}},Int64}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}}},String,Atom.ToplevelCall})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}}},String,Atom.ToplevelMacroCall})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{Type{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}}},String,Atom.ToplevelModuleUsage})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Type{JSON.Writer.CompositeTypeWrapper},Atom.CompletionSuggestion,NTuple{9,Symbol}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{Type{Set},Array{OutlineItem,1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.appendline),String,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.completion),Module,FuzzyCompletions.DictCompletion,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.completion),Module,FuzzyCompletions.FieldCompletion,String})); catch err; @debug err; end
@@ -110,7 +112,6 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(Atom.evalshow),String,Int64,String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.finddevpackages)})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.fullREPLpath),String})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Atom.fullpath),String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.fuzzycompletionadapter),String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.getmodule),String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.handlemsg),Dict{String,Any},String})); catch err; @debug err; end
@@ -160,10 +161,11 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Array{Symbol,1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Atom.Undefined})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Base.EnvDict})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{Int64,Base.GenericCondition{Base.AlwaysLockedST}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{Method,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{String,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{String,Array{String,1}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{String,Dict{String,Array{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}},1}}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Dict{String,Dict{String,Array{Atom.GotoItem,1}}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,ErrorException})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Float16})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Atom.wsicon),Module,Symbol,Float32})); catch err; @debug err; end
@@ -187,10 +189,13 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.broadcasted),Function,Array{Atom.ActualLocalBinding,1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{Dict{Symbol,Any},1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.localdatatip),Tuple{Base.Broadcast.Extruded{Array{Atom.ActualLocalBinding,1},Tuple{Bool},Tuple{Int64}},Base.RefValue{SubString{String}},Int64}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{Int64,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.localdatatip),Tuple{Base.Broadcast.Extruded{Array{Atom.ActualLocalBinding,1},Tuple{Bool},Tuple{Int64}},Base.RefValue{SubString{String}},Int64}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{NamedTuple{(:name, :type, :icon, :start, :stop),Tuple{String,String,String,Int64,Int64}},1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{Nothing,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Base.Broadcast.copyto_nonleaf!),Array{OutlineItem,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.Broadcast.materialize),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Nothing,typeof(Atom.localdatatip),Tuple{Array{Atom.ActualLocalBinding,1},Base.RefValue{SubString{String}},Int64}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(Base.Broadcast.restart_copyto_nonleaf!),Array{Union{Nothing, NamedTuple{(:name, :type, :icon, :start, :stop),Tuple{String,String,String,Int64,Int64}}},1},Array{Nothing,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},NamedTuple{(:name, :type, :icon, :start, :stop),Tuple{String,String,String,Int64,Int64}},Int64,Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Base.Broadcast.restart_copyto_nonleaf!),Array{Union{Nothing, OutlineItem},1},Array{Nothing,1},Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},OutlineItem,Int64,Base.OneTo{Int64},Int64,Int64})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Base._promote_typejoin),Type{Nothing},Type{OutlineItem}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Base.allocatedinline),Type{Atom.GotoItem}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(Base.allocatedinline),Type{Dict{String,Array{Atom.GotoItem,1}}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.collect_to!),Array{Any,1},Base.Generator{Array{Any,1},typeof(Atom.renderMDinline)},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.collect_to!),Array{Hiccup.Node,1},Base.Generator{Array{Any,1},typeof(Atom.renderMD)},Int64,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(Base.collect_to_with_first!),Array{Dict{Symbol,Any},1},Dict{Symbol,Any},Base.Generator{Array{DocSeeker.DocObj,1},typeof(Atom.renderitem)},Int64})); catch err; @debug err; end
@@ -232,6 +237,8 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(Media.render),Juno.Inline,Type{T} where T})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(clearsymbols)})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(convert),Type{Union{Nothing, Atom.Binding}},Atom.Binding})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(delete!),Dict{String,Dict{String,Array{Atom.GotoItem,1}}},String})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(findfirst),Function,Array{Atom.CompletionSuggestion,1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getdocs),Module,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getfield′),Any,String,Atom.Undefined})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getfield′),Any,String})); catch err; @debug err; end
@@ -240,11 +247,17 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(getfield′),Module,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getfield′),Module,Symbol,Function})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(getfield′),Module,Symbol})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(getindex),Array{Atom.CompletionSuggestion,1},Array{Int64,1}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(getindex),Dict{String,Array{Atom.GotoItem,1}},String})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(getproperty),Atom.GotoItem,Symbol})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(globaldatatip),String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(globalgotoitems),String,Module,Nothing,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(globalgotoitems),String,Module,String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(globalgotoitems_unloaded),String,String})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(in),OutlineItem,Set{OutlineItem}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(isempty),Array{Atom.GotoItem,1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isempty),Array{Atom.ToplevelItem,1}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(isempty),Array{OutlineItem,1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(ismacro),Function})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(ismacro),String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Array{Any,1}})); catch err; @debug err; end
@@ -253,10 +266,11 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(isundefined),Atom.Undefined})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Base.RefValue{Bool}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Base.RefValue{Tuple{String,Int64}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(isundefined),Dict{Int64,Base.GenericCondition{Base.AlwaysLockedST}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Dict{Method,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Dict{String,Any}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Dict{String,Array{String,1}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(isundefined),Dict{String,Dict{String,Array{NamedTuple{(:name, :text, :file, :line),Tuple{String,String,String,Int64}},1}}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(isundefined),Dict{String,Dict{String,Array{Atom.GotoItem,1}}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Function})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),HTML{String}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Int64})); catch err; @debug err; end
@@ -265,6 +279,12 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(isundefined),Regex})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(isundefined),Type{T} where T})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(length),Base.KeySet{String,Dict{String,Array{Atom.GotoItem,1}}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(length),Base.KeySet{String,Dict{String,Dict{String,Array{Atom.GotoItem,1}}}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(length),Dict{String,Array{Atom.GotoItem,1}}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(map),Function,Array{Atom.CompletionSuggestion,1}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(map),Function,Array{Atom.GotoItem,1}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(map),Function,Array{OutlineItem,1}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(moduledefinition),Module})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(modulefiles),Module})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(modulefiles),String,String})); catch err; @debug err; end
@@ -272,15 +292,19 @@ function _precompile_()
     try; @assert(precompile(Tuple{typeof(searchcodeblocks),MD})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(searchdocs′),String,Bool,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(searchdocs′),String})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(setindex!),Array{OutlineItem,1},OutlineItem,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.localdatatip),Tuple{Base.Broadcast.Extruded{Array{Atom.ActualLocalBinding,1},Tuple{Bool},Tuple{Int64}},Base.RefValue{SubString{String}},Int64}},Type{Dict{Symbol,Any}}})); catch err; @debug err; end
-    try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Type{NamedTuple{(:name, :type, :icon, :start, :stop),Tuple{String,String,String,Int64,Int64}}}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Type{Nothing}})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(similar),Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1},Tuple{Base.OneTo{Int64}},typeof(Atom.outlineitem),Tuple{Base.Broadcast.Extruded{Array{Atom.ToplevelItem,1},Tuple{Bool},Tuple{Int64}}}},Type{OutlineItem}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(sprint),Function,Base.Generator{CSTParser.EXPR,typeof(Atom.str_value)}})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(strlimit),String,Int64})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(toplevelitems),String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(updatesymbols),String,Nothing,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(updatesymbols),String,String,String})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(use_compiled_modules)})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(vcat),OutlineItem,OutlineItem,OutlineItem,Vararg{OutlineItem,N} where N})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(workspace),String})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(|>),Array{Atom.CompletionSuggestion,1},typeof(length)})); catch err; @debug err; end
+    try; @assert(precompile(Tuple{typeof(|>),Array{Atom.GotoItem,1},typeof(isempty)})); catch err; @debug err; end
     try; @assert(precompile(Tuple{typeof(|>),Array{Atom.ToplevelItem,1},typeof(length)})); catch err; @debug err; end
 end

--- a/test/completions/fuzzycompletions.jl
+++ b/test/completions/fuzzycompletions.jl
@@ -1,11 +1,11 @@
 let
 
-using FuzzyCompletions
+using Atom.FuzzyCompletions
 
 comps(line; mod = "Main", context = "", row = 1, column = 1, force = false) =
     Atom.fuzzycompletionadapter(line, mod, context, row, column, force)
 # emurate `getSuggestionDetailsOnSelect` API
-add_details!(c) = Atom.completiondetail!(c)
+add_details!(c) = Atom.completiondetail!(JSON.parse(json(c)))
 
 @testset "module completion" begin
     ## basic
@@ -75,8 +75,8 @@ end
             # shows module where the method defined in right label
             @test c[:rightLabel] == string(mod)
 
-            add_details!(c)
-            @test c[:leftLabel] == "String" # shows the infered return type in left label from method signature
+            c = add_details!(c)
+            @test c["leftLabel"] == "String" # shows the infered return type in left label from method signature
         end
 
         # shows the infered return type in left label from input types
@@ -89,8 +89,8 @@ end
             @test c[:type] == "method"
             @test c[:rightLabel] == string(mod)
 
-            add_details!(c)
-            @test c[:leftLabel] == "" # don't show a return type when it can't be inferred
+            c = add_details!(c)
+            @test c["leftLabel"] == "" # don't show a return type when it can't be inferred
         end
         let cs = comps("f(1, "; mod = string(mod))
             filter!(c -> c[:text] == "f(a)", cs)
@@ -101,11 +101,11 @@ end
             @test c[:rightLabel] == string(mod)
 
             # infer return type with input types
-            add_details!(c)
+            c = add_details!(c)
             @static if VERSION ≥ v"1.1"
-                @test c[:leftLabel] == "$(Int)"
+                @test c["leftLabel"] == "$(Int)"
             else
-                @test_broken c[:leftLabel] == "$(Int)"
+                @test_broken c["leftLabel"] == "$(Int)"
             end
         end
 
@@ -166,8 +166,8 @@ end
         c = cs[i]
         @test c[:type] == "keyword"
         @test isempty(c[:rightLabel])
-        add_details!(c)
-        @test !isempty(c[:description])
+        c = add_details!(c)
+        @test !isempty(c["description"])
     end
 end
 

--- a/test/completions/fuzzycompletions.jl
+++ b/test/completions/fuzzycompletions.jl
@@ -12,9 +12,9 @@ add_details!(c) = Atom.completiondetail!(JSON.parse(json(c)))
     let line = "@", cs = comps(line, mod = "Atom")
         # test detecting all the macros in Atom module
         @test filter(cs) do c
-            c[:type] == "snippet" &&
-            c[:icon] == "icon-mention" &&
-            c[:rightLabel] == "Atom"
+            c.type == "snippet" &&
+            c.icon == "icon-mention" &&
+            c.rightLabel == "Atom"
         end |> length == filter(names(Atom, all=true, imported=true)) do n
             startswith(string(n), '@')
         end |> length
@@ -23,8 +23,8 @@ add_details!(c) = Atom.completiondetail!(JSON.parse(json(c)))
     ## advanced
     let cs = comps("match(code", mod = "Atom")
         @test filter(cs) do c
-            c[:text] == "codeblock_regex" &&
-            c[:rightLabel] == "Atom"
+            c.text == "codeblock_regex" &&
+            c.rightLabel == "Atom"
         end |> !isempty
     end
 
@@ -44,7 +44,7 @@ end
         @test length(cs) == length(FuzzyCompletions.completions(line, lastindex(line))[1])
         # test detecting all the `push!` methods available
         @test filter(cs) do c
-            c[:type] == "method"
+            c.type == "method"
         end |> length == length(methods(push!))
     end
 
@@ -53,7 +53,7 @@ end
     let mod = Main.eval(:(module $(gensym("tempmod")) end))
         # initial state check
         let cs = comps(line)
-            filter!(c -> c[:text] == "push!(::$(mod).Singleton)", cs)
+            filter!(c -> c.text == "push!(::$(mod).Singleton)", cs)
             @test isempty(cs)
         end
 
@@ -67,13 +67,13 @@ end
             push!(::Singleton) = ""
         end
         let cs = comps(line)
-            filter!(c -> c[:text] == "push!(::$(mod).Singleton)", cs)
+            filter!(c -> c.text == "push!(::$(mod).Singleton)", cs)
             # dynamic method addition
             @test length(cs) === 1
             c = cs[1]
-            @test c[:type] == "method"
+            @test c.type == "method"
             # shows module where the method defined in right label
-            @test c[:rightLabel] == string(mod)
+            @test c.rightLabel == string(mod)
 
             c = add_details!(c)
             @test c["leftLabel"] == "String" # shows the infered return type in left label from method signature
@@ -82,23 +82,23 @@ end
         # shows the infered return type in left label from input types
         @eval mod f(a) = a
         let cs = comps("f("; mod = string(mod))
-            filter!(c -> c[:text] == "f(a)", cs)
+            filter!(c -> c.text == "f(a)", cs)
             @test length(cs) === 1
             c = cs[1]
-            @test c[:text] == "f(a)"
-            @test c[:type] == "method"
-            @test c[:rightLabel] == string(mod)
+            @test c.text == "f(a)"
+            @test c.type == "method"
+            @test c.rightLabel == string(mod)
 
             c = add_details!(c)
             @test c["leftLabel"] == "" # don't show a return type when it can't be inferred
         end
         let cs = comps("f(1, "; mod = string(mod))
-            filter!(c -> c[:text] == "f(a)", cs)
+            filter!(c -> c.text == "f(a)", cs)
             @test length(cs) === 1
             c = cs[1]
-            @test c[:text] == "f(a)"
-            @test c[:type] == "method"
-            @test c[:rightLabel] == string(mod)
+            @test c.text == "f(a)"
+            @test c.type == "method"
+            @test c.rightLabel == string(mod)
 
             # infer return type with input types
             c = add_details!(c)
@@ -115,8 +115,8 @@ end
         end
         @test_nowarn let cs = comps("g("; mod = string(mod))
             @test !isempty(cs)
-            @test cs[1][:type] == "method"
-            @test cs[1][:text] == "g(x)"
+            @test cs[1].type == "method"
+            @test cs[1].text == "g(x)"
         end
     end
 end
@@ -129,9 +129,9 @@ let m = Main.eval(:(module $(gensym("tempmod")) end))
     @testset "property completion" begin
         props = string.(propertynames(m.dict))
         foreach(comps("dict.", mod = ms)) do c
-            @test c[:text] in props
-            @test c[:type] == "property"
-            @test c[:rightLabel] == ms
+            @test c.text in props
+            @test c.type == "property"
+            @test c.rightLabel == ms
         end
     end
 
@@ -139,21 +139,21 @@ let m = Main.eval(:(module $(gensym("tempmod")) end))
         line = "split(\"\", \"\")[1]."
         fields = string.(fieldnames(SubString{String}))
         foreach(comps(line, mod = ms)) do c
-            @test c[:text] in fields
-            @test c[:type] == "property"
-            @test c[:rightLabel] == "SubString{String}" # the type of object who has those fields
-            @test c[:leftLabel] == string(fieldtype(SubString{String}, Symbol(c[:text])))
+            @test c.text in fields
+            @test c.type == "property"
+            @test c.rightLabel == "SubString{String}" # the type of object who has those fields
+            @test c.leftLabel == string(fieldtype(SubString{String}, Symbol(c.text)))
         end
     end
 
     @testset "dictionary completion" begin
         ks = repr.(keys(m.dict))
         foreach(comps("dict[", mod = ms)) do c
-            @test c[:text] in ks
-            @test c[:type] == "property"
-            @test c[:icon] == "icon-key"
-            @test c[:rightLabel] == ms
-            @test c[:leftLabel] == string(Int)
+            @test c.text in ks
+            @test c.type == "property"
+            @test c.icon == "icon-key"
+            @test c.rightLabel == ms
+            @test c.leftLabel == string(Int)
         end
     end
 end
@@ -161,11 +161,11 @@ end
 @testset "keyword completion" begin
     for line in ["begin", "beg", "bgin", "bg"]
         cs = comps(line)
-        i = findfirst(c -> c[:text] == "begin", cs)
+        i = findfirst(c -> c.text == "begin", cs)
         @test i !== nothing
         c = cs[i]
-        @test c[:type] == "keyword"
-        @test isempty(c[:rightLabel])
+        @test c.type == "keyword"
+        @test isempty(c.rightLabel)
         c = add_details!(c)
         @test !isempty(c["description"])
     end
@@ -181,9 +181,9 @@ end
           length(REPLCompletions.completions(line, lastindex(line))[1]) ==
           length(readdir(pwd()))
     foreach(cs) do c
-        @test c[:type] == "path"
-        @test c[:icon] == "icon-file"
-        @test c[:rightLabel] |> isempty
+        @test c.type == "path"
+        @test c.icon == "icon-file"
+        @test c.rightLabel |> isempty
     end
 end
 
@@ -218,41 +218,41 @@ end
         # local completions ordered by proximity
         prefix = "a"
         let c = comps′(prefix, 3, 6)[1]
-            @test c[:text] == "aaa"
-            @test c[:rightLabel] == "foo"
-            @test c[:type] == type
-            @test c[:icon] == icon
-            @test c[:description] == "aaa = 3"
+            @test c.text == "aaa"
+            @test c.rightLabel == "foo"
+            @test c.type == type
+            @test c.icon == icon
+            @test c.description == "aaa = 3"
         end
         let c = comps′(prefix, 6, 6)[1]
-            @test c[:text] == "aaa"
-            @test c[:rightLabel] == "foo"
-            @test c[:type] == type
-            @test c[:icon] == icon
-            @test c[:description] == "aaa = 3"
+            @test c.text == "aaa"
+            @test c.rightLabel == "foo"
+            @test c.type == type
+            @test c.icon == icon
+            @test c.description == "aaa = 3"
         end
         let c = comps′(prefix, 8, 6)[1]
-            @test c[:text] == "abc"
-            @test c[:rightLabel] == "foo"
-            @test c[:type] == type
-            @test c[:icon] == icon
-            @test c[:description] == "abc = 3"
+            @test c.text == "abc"
+            @test c.rightLabel == "foo"
+            @test c.type == type
+            @test c.icon == icon
+            @test c.description == "abc = 3"
         end
 
         # show a bound line as is if binding verbatim is not so useful
         let c = comps′("x", 5, 13)[1]
-            @test c[:text] == "x"
-            @test c[:rightLabel] == "foo"
-            @test c[:type] == type
-            @test c[:icon] == icon
-            @test c[:description] == "function foo(x)"
+            @test c.text == "x"
+            @test c.rightLabel == "foo"
+            @test c.type == type
+            @test c.icon == icon
+            @test c.description == "function foo(x)"
         end
 
         # show all the local bindings in order when forcibly invoked
         let cs = comps′("", 6, 6, true)
-            inds = findall(c -> c[:type] == type && c[:icon] == icon, cs)
+            inds = findall(c -> c.type == type && c.icon == icon, cs)
             @test inds == [1, 2, 3, 4]
-            @test map(c -> c[:text], cs[inds]) == ["foo", "aaa", "x", "abc"]
+            @test map(c -> c.text, cs[inds]) == ["foo", "aaa", "x", "abc"]
         end
 
         # suppress local completions when in "troublemaker" cases

--- a/test/completions/replcompletions.jl
+++ b/test/completions/replcompletions.jl
@@ -5,7 +5,7 @@ using REPL.REPLCompletions
 comps(line; mod = "Main", context = "", row = 1, column = 1, force = false) =
     Atom.replcompletionadapter(line, mod, context, row, column, force)
 # emurate `getSuggestionDetailsOnSelect` API
-add_details!(c) = Atom.completiondetail!(c)
+add_details!(c) = Atom.completiondetail!(JSON.parse(json(c)))
 
 @testset "module completion" begin
     ## basic
@@ -78,8 +78,8 @@ end
             # shows module where the method defined in right label
             @test c[:rightLabel] == string(mod)
 
-            add_details!(c)
-            @test c[:leftLabel] == "String" # shows the infered return type in left label from method signature
+            c = add_details!(c)
+            @test c["leftLabel"] == "String" # shows the infered return type in left label from method signature
         end
 
         # shows the infered return type in left label from input types
@@ -92,8 +92,8 @@ end
             @test c[:type] == "method"
             @test c[:rightLabel] == string(mod)
 
-            add_details!(c)
-            @test c[:leftLabel] == "" # don't show a return type when it can't be inferred
+            c = add_details!(c)
+            @test c["leftLabel"] == "" # don't show a return type when it can't be inferred
         end
         let cs = comps("f(1, "; mod = string(mod))
             filter!(c -> c[:text] == "f(a)", cs)
@@ -104,11 +104,11 @@ end
             @test c[:rightLabel] == string(mod)
 
             # infer return type with input types
-            add_details!(c)
+            c = add_details!(c)
             @static if VERSION ≥ v"1.1"
-                @test c[:leftLabel] == "$(Int)"
+                @test c["leftLabel"] == "$(Int)"
             else
-                @test_broken c[:leftLabel] == "$(Int)"
+                @test_broken c["leftLabel"] == "$(Int)"
             end
         end
 
@@ -168,8 +168,8 @@ end
     c = cs[i]
     @test c[:type] == "keyword"
     @test isempty(c[:rightLabel])
-    add_details!(c)
-    @test !isempty(c[:description])
+    c = add_details!(c)
+    @test !isempty(c["description"])
 end
 
 @testset "path completion" begin

--- a/test/completions/replcompletions.jl
+++ b/test/completions/replcompletions.jl
@@ -15,9 +15,9 @@ add_details!(c) = Atom.completiondetail!(JSON.parse(json(c)))
 
         # test detecting all the macros in Atom module
         @test filter(cs) do c
-            c[:type] == "snippet" &&
-            c[:icon] == "icon-mention" &&
-            c[:rightLabel] == "Atom"
+            c.type == "snippet" &&
+            c.icon == "icon-mention" &&
+            c.rightLabel == "Atom"
         end |> length == filter(names(Atom, all=true, imported=true)) do n
             startswith(string(n), '@')
         end |> length
@@ -26,8 +26,8 @@ add_details!(c) = Atom.completiondetail!(JSON.parse(json(c)))
     ## advanced
     let cs = comps("match(code", mod = "Atom")
         @test filter(cs) do c
-            c[:text] == "codeblock_regex" &&
-            c[:rightLabel] == "Atom"
+            c.text == "codeblock_regex" &&
+            c.rightLabel == "Atom"
         end |> !isempty
     end
 
@@ -47,7 +47,7 @@ end
         @test length(cs) == length(REPLCompletions.completions(line, lastindex(line))[1])
         # test detecting all the `push!` methods available
         @test filter(cs) do c
-            c[:type] == "method"
+            c.type == "method"
         end |> length == length(methods(push!))
     end
 
@@ -56,7 +56,7 @@ end
     let mod = Main.eval(:(module $(gensym("tempmod")) end))
         # initial state check
         let cs = comps(line)
-            filter!(c -> c[:text] == "push!(::$(mod).Singleton)", cs)
+            filter!(c -> c.text == "push!(::$(mod).Singleton)", cs)
             @test isempty(cs)
         end
 
@@ -70,13 +70,13 @@ end
             push!(::Singleton) = ""
         end
         let cs = comps(line)
-            filter!(c -> c[:text] == "push!(::$(mod).Singleton)", cs)
+            filter!(c -> c.text == "push!(::$(mod).Singleton)", cs)
             # dynamic method addition
             @test length(cs) === 1
             c = cs[1]
-            @test c[:type] == "method"
+            @test c.type == "method"
             # shows module where the method defined in right label
-            @test c[:rightLabel] == string(mod)
+            @test c.rightLabel == string(mod)
 
             c = add_details!(c)
             @test c["leftLabel"] == "String" # shows the infered return type in left label from method signature
@@ -85,23 +85,23 @@ end
         # shows the infered return type in left label from input types
         @eval mod f(a) = a
         let cs = comps("f("; mod = string(mod))
-            filter!(c -> c[:text] == "f(a)", cs)
+            filter!(c -> c.text == "f(a)", cs)
             @test length(cs) === 1
             c = cs[1]
-            @test c[:text] == "f(a)"
-            @test c[:type] == "method"
-            @test c[:rightLabel] == string(mod)
+            @test c.text == "f(a)"
+            @test c.type == "method"
+            @test c.rightLabel == string(mod)
 
             c = add_details!(c)
             @test c["leftLabel"] == "" # don't show a return type when it can't be inferred
         end
         let cs = comps("f(1, "; mod = string(mod))
-            filter!(c -> c[:text] == "f(a)", cs)
+            filter!(c -> c.text == "f(a)", cs)
             @test length(cs) === 1
             c = cs[1]
-            @test c[:text] == "f(a)"
-            @test c[:type] == "method"
-            @test c[:rightLabel] == string(mod)
+            @test c.text == "f(a)"
+            @test c.type == "method"
+            @test c.rightLabel == string(mod)
 
             # infer return type with input types
             c = add_details!(c)
@@ -118,8 +118,8 @@ end
         end
         @test_nowarn let cs = comps("g("; mod = string(mod))
             @test !isempty(cs)
-            @test cs[1][:type] == "method"
-            @test cs[1][:text] == "g(x)"
+            @test cs[1].type == "method"
+            @test cs[1].text == "g(x)"
         end
     end
 end
@@ -132,9 +132,9 @@ let m = Main.eval(:(module $(gensym("tempmod")) end))
     @testset "property completion" begin
         props = string.(propertynames(m.dict))
         foreach(comps("dict.", mod = ms)) do c
-            @test c[:text] in props
-            @test c[:type] == "property"
-            @test c[:rightLabel] == ms
+            @test c.text in props
+            @test c.type == "property"
+            @test c.rightLabel == ms
         end
     end
 
@@ -142,32 +142,32 @@ let m = Main.eval(:(module $(gensym("tempmod")) end))
         line = "split(\"\", \"\")[1]."
         fields = string.(fieldnames(SubString{String}))
         foreach(comps(line, mod = ms)) do c
-            @test c[:text] in fields
-            @test c[:type] == "property"
-            @test c[:rightLabel] == "SubString{String}" # the type of object who has those fields
-            @test c[:leftLabel] == string(fieldtype(SubString{String}, Symbol(c[:text])))
+            @test c.text in fields
+            @test c.type == "property"
+            @test c.rightLabel == "SubString{String}" # the type of object who has those fields
+            @test c.leftLabel == string(fieldtype(SubString{String}, Symbol(c.text)))
         end
     end
 
     @testset "dictionary completion" begin
         ks = repr.(keys(m.dict))
         foreach(comps("dict[", mod = ms)) do c
-            @test c[:text] in ks
-            @test c[:type] == "property"
-            @test c[:icon] == "icon-key"
-            @test c[:rightLabel] == ms
-            @test c[:leftLabel] == string(Int)
+            @test c.text in ks
+            @test c.type == "property"
+            @test c.icon == "icon-key"
+            @test c.rightLabel == ms
+            @test c.leftLabel == string(Int)
         end
     end
 end
 
 @testset "keyword completion" begin
     cs = comps("begin")
-    i = findfirst(c -> c[:text] == "begin", cs)
+    i = findfirst(c -> c.text == "begin", cs)
     @test i !== nothing
     c = cs[i]
-    @test c[:type] == "keyword"
-    @test isempty(c[:rightLabel])
+    @test c.type == "keyword"
+    @test isempty(c.rightLabel)
     c = add_details!(c)
     @test !isempty(c["description"])
 end
@@ -182,9 +182,9 @@ end
           length(REPLCompletions.completions(line, lastindex(line))[1]) ==
           length(readdir(pwd()))
     foreach(cs) do c
-        @test c[:type] == "path"
-        @test c[:icon] == "icon-file"
-        @test c[:rightLabel] |> isempty
+        @test c.type == "path"
+        @test c.icon == "icon-file"
+        @test c.rightLabel |> isempty
     end
 end
 
@@ -219,41 +219,41 @@ end
         # local completions ordered by proximity
         prefix = "a"
         let c = comps′(prefix, 3, 6)[1]
-            @test c[:text] == "aaa"
-            @test c[:rightLabel] == "foo"
-            @test c[:type] == type
-            @test c[:icon] == icon
-            @test c[:description] == "aaa = 3"
+            @test c.text == "aaa"
+            @test c.rightLabel == "foo"
+            @test c.type == type
+            @test c.icon == icon
+            @test c.description == "aaa = 3"
         end
         let c = comps′(prefix, 6, 6)[1]
-            @test c[:text] == "aaa"
-            @test c[:rightLabel] == "foo"
-            @test c[:type] == type
-            @test c[:icon] == icon
-            @test c[:description] == "aaa = 3"
+            @test c.text == "aaa"
+            @test c.rightLabel == "foo"
+            @test c.type == type
+            @test c.icon == icon
+            @test c.description == "aaa = 3"
         end
         let c = comps′(prefix, 8, 6)[1]
-            @test c[:text] == "abc"
-            @test c[:rightLabel] == "foo"
-            @test c[:type] == type
-            @test c[:icon] == icon
-            @test c[:description] == "abc = 3"
+            @test c.text == "abc"
+            @test c.rightLabel == "foo"
+            @test c.type == type
+            @test c.icon == icon
+            @test c.description == "abc = 3"
         end
 
         # show a bound line as is if binding verbatim is not so useful
         let c = comps′("x", 5, 13)[1]
-            @test c[:text] == "x"
-            @test c[:rightLabel] == "foo"
-            @test c[:type] == type
-            @test c[:icon] == icon
-            @test c[:description] == "function foo(x)"
+            @test c.text == "x"
+            @test c.rightLabel == "foo"
+            @test c.type == type
+            @test c.icon == icon
+            @test c.description == "function foo(x)"
         end
 
         # show all the local bindings in order when forcibly invoked
         let cs = comps′("", 6, 6, true)
-            inds = findall(c -> c[:type] == type && c[:icon] == icon, cs)
+            inds = findall(c -> c.type == type && c.icon == icon, cs)
             @test inds == [1, 2, 3, 4]
-            @test map(c -> c[:text], cs[inds]) == ["foo", "aaa", "x", "abc"]
+            @test map(c -> c.text, cs[inds]) == ["foo", "aaa", "x", "abc"]
         end
 
         # suppress local completions when in "troublemaker" cases

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -1,6 +1,4 @@
 @testset "goto symbols" begin
-    using Atom: todict
-
     @testset "goto local symbols" begin
         let str = """
             function localgotoitem(word, path, column, row, startRow, context) # L0
@@ -17,7 +15,7 @@
               end                                                              # L11
             end                                                                # L12
             """,
-            localgotoitem(word, line) = Atom.localgotoitem(word, "path", typemax(Int), line + 1, 0, str)[1] |> todict
+            localgotoitem(word, line) = Atom.localgotoitem(word, "path", typemax(Int), line + 1, 0, str)[1]
 
             let item = localgotoitem("row", 2)
                 @test item[:line] === 0
@@ -37,14 +35,14 @@
                 return val
             end
             """,
-            localgotoitem(word, line) = Atom.localgotoitem(word, "path", typemax(Int), line + 1, 0, str)[1] |> todict
+            localgotoitem(word, line) = Atom.localgotoitem(word, "path", typemax(Int), line + 1, 0, str)[1]
 
             @test localgotoitem("expr.args", 1)[:line] === 0
             @test localgotoitem("bind.val", 2)[:line] === 1
         end
 
         # don't error on fallback case
-        @test_nowarn @test Atom.localgotoitem("word", nothing, 1, 1, 0, "") == []
+        @test (Atom.localgotoitem("word", nothing, 1, 1, 0, ""); true)
     end
 
     @testset "goto global symbols" begin
@@ -55,11 +53,11 @@
         let
             path = joinpath′(@__DIR__, "..", "src", "comm.jl")
             text = read(path, String)
-            items = todict.(globalgotoitems("Atom.handlers", Atom, path, text))
+            items = globalgotoitems("Atom.handlers", Atom, path, text)
             @test !isempty(items)
             @test items[1][:file] == path
             @test items[1][:text] == "handlers"
-            items = todict.(globalgotoitems("Main.Atom.handlers", Atom, path, text))
+            items = globalgotoitems("Main.Atom.handlers", Atom, path, text)
             @test !isempty(items)
             @test items[1][:file] == path
             @test items[1][:text] == "handlers"
@@ -67,18 +65,18 @@
             # can access the non-exported (non-method) bindings in the other module
             path = joinpath′(@__DIR__, "..", "src", "goto.jl")
             text = read(@__FILE__, String)
-            items = todict.(globalgotoitems("Atom.SYMBOLSCACHE", Main, @__FILE__, text))
+            items = globalgotoitems("Atom.SYMBOLSCACHE", Main, @__FILE__, text)
             @test !isempty(items)
             @test items[1][:file] == path
             @test items[1][:text] == "SYMBOLSCACHE"
         end
 
         @testset "goto modules" begin
-            let item = globalgotoitems("Atom", Main, nothing, "")[1] |> todict
+            let item = globalgotoitems("Atom", Main, nothing, "")[1]
                 @test item[:file] == joinpath′(atomsrcdir, "Atom.jl")
                 @test item[:line] == 3
             end
-            let item = globalgotoitems("SubJunk", Junk, nothing, "")[1] |> todict
+            let item = globalgotoitems("SubJunk", Junk, nothing, "")[1]
                 @test item[:file] == subjunkspath
                 @test item[:line] == 3
             end
@@ -92,7 +90,7 @@
                 word = "handlers"
 
                 # basic
-                let items = todict.(toplevelgotoitems(word, mod, path, ""))
+                let items = toplevelgotoitems(word, mod, path, "")
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:text] == word
@@ -105,7 +103,7 @@
                 @test length(SYMBOLSCACHE[key]) == length(atommodfiles)
 
                 # when `path` isn't given, i.e. via docpane / workspace
-                let items = todict.(toplevelgotoitems(word, mod, nothing, ""))
+                let items = toplevelgotoitems(word, mod, nothing, "")
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:text] == word
@@ -114,7 +112,7 @@
                 # same as above, but without any previous cache -- falls back to CSTPraser-based module-walk
                 delete!(SYMBOLSCACHE, key)
 
-                let items = toplevelgotoitems(word, mod, nothing, "") .|> todict
+                let items = toplevelgotoitems(word, mod, nothing, "")
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:text] == word
@@ -132,7 +130,7 @@
                 word = "toplevelval"
 
                 # basic -- no need to pass a buffer text
-                let items = toplevelgotoitems(word, mod, path, "") .|> todict
+                let items = toplevelgotoitems(word, mod, path, "")
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:line] == 14
@@ -143,7 +141,7 @@
                 @test haskey(Atom.SYMBOLSCACHE, key)
 
                 # when `path` isn't given, i.e.: via docpane / workspace
-                let items = toplevelgotoitems(word, mod, nothing, "") .|> todict
+                let items = toplevelgotoitems(word, mod, nothing, "")
                     @test !isempty(items)
                     @test items[1][:file] == path
                     @test items[1][:line] == 14
@@ -163,7 +161,7 @@
                 mod = Main.Junk.SubJunk
                 word = "imwithdoc"
 
-                items = toplevelgotoitems(word, mod, path, text) .|> todict
+                items = toplevelgotoitems(word, mod, path, text)
                 @test length(items) === 1
                 if length(items) === 1
                     @test items[1][:file] == path
@@ -178,10 +176,9 @@
                 mod = Main
                 word = "atomsrcdir"
 
-                items = toplevelgotoitems(word, mod, path, text) .|> todict
+                items = toplevelgotoitems(word, mod, path, text)
                 @test !isempty(items)
                 @test items[1][:file] == path
-                @test items[1][:line] == 6
                 @test items[1][:text] == word
             end
 
@@ -224,7 +221,7 @@
                 item.name == word
             end |> !isempty
 
-            let items = toplevelgotoitems(word, mod, path, newtext) .|> todict
+            let items = toplevelgotoitems(word, mod, path, newtext)
                 @test !isempty(items)
                 @test items[1][:file] == path
                 @test items[1][:text] == "toplevelval2"
@@ -245,7 +242,7 @@
             SYMBOLSCACHE["Atom"][atomjlfile] = prevstate
 
             # don't error on fallback case
-            @test_nowarn @test updatesymbols(key, nothing, text) === nothing
+            @test (updatesymbols(key, nothing, text); true)
         end
 
         @testset "regenerating toplevel symbols" begin
@@ -283,23 +280,23 @@
             end
 
             ## aggregate methods with default params
-            @eval Main function funcwithdefaultargs(args, defarg = "default") end
+            let m = eval(:(module $(gensym(:atomjltestmodule)) end))
+                @eval m function funcwithdefaultargs(args, defarg = "default") end
+                let items = methodgotoitems(methods(m.funcwithdefaultargs))
+                    # should be handled as an unique method
+                    @test length(items) === 1
+                    # show a method with full arguments
+                    @test "funcwithdefaultargs(args, defarg)" in map(i -> i[:text], items)
+                end
 
-            let items = methodgotoitems(methods(funcwithdefaultargs)) .|> todict
-                # should be handled as an unique method
-                @test length(items) === 1
-                # show a method with full arguments
-                @test "funcwithdefaultargs(args, defarg)" in map(i -> i[:text], items)
-            end
-
-            @eval Main function funcwithdefaultargs(args::String, defarg = "default") end
-
-            let items = methodgotoitems(methods(funcwithdefaultargs)) .|> todict
-                # should be handled as different methods
-                @test length(items) === 2
-                # show methods with full arguments
-                @test "funcwithdefaultargs(args, defarg)" in map(i -> i[:text], items)
-                @test "funcwithdefaultargs(args::String, defarg)" in map(i -> i[:text], items)
+                @eval m function funcwithdefaultargs(args::String, defarg = "default") end
+                let items = methodgotoitems(methods(m.funcwithdefaultargs))
+                    # should be handled as different methods
+                    @test length(items) === 2
+                    # show methods with full arguments
+                    @test "funcwithdefaultargs(args, defarg)" in map(i -> i[:text], items)
+                    @test "funcwithdefaultargs(args::String, defarg)" in map(i -> i[:text], items)
+                end
             end
         end
 
@@ -311,6 +308,6 @@
         end
 
         ## don't error on the fallback case
-        @test_nowarn @test globalgotoitems("word", Main, nothing, "") == []
+        @test (globalgotoitems("word", Main, nothing, ""); true)
     end
 end

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -18,13 +18,13 @@
             localgotoitem(word, line) = Atom.localgotoitem(word, "path", typemax(Int), line + 1, 0, str)[1]
 
             let item = localgotoitem("row", 2)
-                @test item[:line] === 0
-                @test item[:text] == "row"
-                @test item[:file] == "path"
+                @test item.line === 0
+                @test item.text == "row"
+                @test item.file == "path"
             end
-            @test localgotoitem("position", 2)[:line] === 1
-            @test localgotoitem("l", 4)[:line] === 3
-            @test localgotoitem("l", 8)[:line] === 7
+            @test localgotoitem("position", 2).line === 1
+            @test localgotoitem("l", 4).line === 3
+            @test localgotoitem("l", 8).line === 7
         end
 
         # ignore dot accessors
@@ -37,8 +37,8 @@
             """,
             localgotoitem(word, line) = Atom.localgotoitem(word, "path", typemax(Int), line + 1, 0, str)[1]
 
-            @test localgotoitem("expr.args", 1)[:line] === 0
-            @test localgotoitem("bind.val", 2)[:line] === 1
+            @test localgotoitem("expr.args", 1).line === 0
+            @test localgotoitem("bind.val", 2).line === 1
         end
 
         # don't error on fallback case
@@ -55,30 +55,30 @@
             text = read(path, String)
             items = globalgotoitems("Atom.handlers", Atom, path, text)
             @test !isempty(items)
-            @test items[1][:file] == path
-            @test items[1][:text] == "handlers"
+            @test items[1].file == path
+            @test items[1].text == "handlers"
             items = globalgotoitems("Main.Atom.handlers", Atom, path, text)
             @test !isempty(items)
-            @test items[1][:file] == path
-            @test items[1][:text] == "handlers"
+            @test items[1].file == path
+            @test items[1].text == "handlers"
 
             # can access the non-exported (non-method) bindings in the other module
             path = joinpath′(@__DIR__, "..", "src", "goto.jl")
             text = read(@__FILE__, String)
             items = globalgotoitems("Atom.SYMBOLSCACHE", Main, @__FILE__, text)
             @test !isempty(items)
-            @test items[1][:file] == path
-            @test items[1][:text] == "SYMBOLSCACHE"
+            @test items[1].file == path
+            @test items[1].text == "SYMBOLSCACHE"
         end
 
         @testset "goto modules" begin
             let item = globalgotoitems("Atom", Main, nothing, "")[1]
-                @test item[:file] == joinpath′(atomsrcdir, "Atom.jl")
-                @test item[:line] == 3
+                @test item.file == joinpath′(atomsrcdir, "Atom.jl")
+                @test item.line == 3
             end
             let item = globalgotoitems("SubJunk", Junk, nothing, "")[1]
-                @test item[:file] == subjunkspath
-                @test item[:line] == 3
+                @test item.file == subjunkspath
+                @test item.line == 3
             end
         end
 
@@ -92,8 +92,8 @@
                 # basic
                 let items = toplevelgotoitems(word, mod, path, "")
                     @test !isempty(items)
-                    @test items[1][:file] == path
-                    @test items[1][:text] == word
+                    @test items[1].file == path
+                    @test items[1].text == word
                 end
 
                 # check caching works
@@ -105,8 +105,8 @@
                 # when `path` isn't given, i.e. via docpane / workspace
                 let items = toplevelgotoitems(word, mod, nothing, "")
                     @test !isempty(items)
-                    @test items[1][:file] == path
-                    @test items[1][:text] == word
+                    @test items[1].file == path
+                    @test items[1].text == word
                 end
 
                 # same as above, but without any previous cache -- falls back to CSTPraser-based module-walk
@@ -114,8 +114,8 @@
 
                 let items = toplevelgotoitems(word, mod, nothing, "")
                     @test !isempty(items)
-                    @test items[1][:file] == path
-                    @test items[1][:text] == word
+                    @test items[1].file == path
+                    @test items[1].text == word
                 end
 
                 # check CSTPraser-based module-walk finds all the included files
@@ -132,9 +132,9 @@
                 # basic -- no need to pass a buffer text
                 let items = toplevelgotoitems(word, mod, path, "")
                     @test !isempty(items)
-                    @test items[1][:file] == path
-                    @test items[1][:line] == 14
-                    @test items[1][:text] == word
+                    @test items[1].file == path
+                    @test items[1].line == 14
+                    @test items[1].text == word
                 end
 
                 # check caching works
@@ -143,9 +143,9 @@
                 # when `path` isn't given, i.e.: via docpane / workspace
                 let items = toplevelgotoitems(word, mod, nothing, "")
                     @test !isempty(items)
-                    @test items[1][:file] == path
-                    @test items[1][:line] == 14
-                    @test items[1][:text] == word
+                    @test items[1].file == path
+                    @test items[1].line == 14
+                    @test items[1].text == word
                 end
             end
 
@@ -164,9 +164,9 @@
                 items = toplevelgotoitems(word, mod, path, text)
                 @test length(items) === 1
                 if length(items) === 1
-                    @test items[1][:file] == path
-                    @test items[1][:line] == 6
-                    @test items[1][:text] == word
+                    @test items[1].file == path
+                    @test items[1].line == 6
+                    @test items[1].text == word
                 end
             end
 
@@ -178,8 +178,8 @@
 
                 items = toplevelgotoitems(word, mod, path, text)
                 @test !isempty(items)
-                @test items[1][:file] == path
-                @test items[1][:text] == word
+                @test items[1].file == path
+                @test items[1].text == word
             end
 
             # don't mix a function and a macro with the same name
@@ -223,8 +223,8 @@
 
             let items = toplevelgotoitems(word, mod, path, newtext)
                 @test !isempty(items)
-                @test items[1][:file] == path
-                @test items[1][:text] == "toplevelval2"
+                @test items[1].file == path
+                @test items[1].text == "toplevelval2"
             end
 
             # re-update the cache
@@ -286,7 +286,7 @@
                     # should be handled as an unique method
                     @test length(items) === 1
                     # show a method with full arguments
-                    @test "funcwithdefaultargs(args, defarg)" in map(i -> i[:text], items)
+                    @test "funcwithdefaultargs(args, defarg)" in map(i -> i.text, items)
                 end
 
                 @eval m function funcwithdefaultargs(args::String, defarg = "default") end
@@ -294,8 +294,8 @@
                     # should be handled as different methods
                     @test length(items) === 2
                     # show methods with full arguments
-                    @test "funcwithdefaultargs(args, defarg)" in map(i -> i[:text], items)
-                    @test "funcwithdefaultargs(args::String, defarg)" in map(i -> i[:text], items)
+                    @test "funcwithdefaultargs(args, defarg)" in map(i -> i.text, items)
+                    @test "funcwithdefaultargs(args::String, defarg)" in map(i -> i.text, items)
                 end
             end
         end

--- a/test/outline.jl
+++ b/test/outline.jl
@@ -1,7 +1,5 @@
 @testset "outline" begin
     using Atom: OutlineItem
-    Atom.OutlineItem(name, type, icon, start, stop) =
-        (name = name, type = type, icon = icon, start = start, stop = stop)
     outline(text) = Atom.outline(Atom.toplevelitems(text))
 
     # basic

--- a/test/outline.jl
+++ b/test/outline.jl
@@ -1,5 +1,7 @@
 @testset "outline" begin
     using Atom: OutlineItem
+    Atom.OutlineItem(name, type, icon, start, stop) =
+        (name = name, type = type, icon = icon, start = start, stop = stop)
     outline(text) = Atom.outline(Atom.toplevelitems(text))
 
     # basic
@@ -34,36 +36,12 @@
         const sss = 3
         end
         """
-        let os = Set(Atom.todict.(outline(str)))
+        let os = Set(outline(str))
             for o in [
-                    Dict(
-                        :type => "module",
-                        :name => "Foo",
-                        :icon => "icon-package",
-                        :start => 1,
-                        :stop => 7
-                    )
-                    Dict(
-                        :type => "function",
-                        :name => "foo(x)",
-                        :icon => "λ",
-                        :start => 2,
-                        :stop => 2
-                    )
-                    Dict(
-                        :type => "function",
-                        :name => "bar(x::Int)",
-                        :icon => "λ",
-                        :start => 3,
-                        :stop => 5
-                    )
-                    Dict(
-                        :type => "constant",
-                        :name => "sss",
-                        :icon => "c",
-                        :start => 6,
-                        :stop => 6
-                    )
+                    OutlineItem("Foo", "module", "icon-package", 1, 7)
+                    OutlineItem("foo(x)", "function", "λ", 2, 2)
+                    OutlineItem("bar(x::Int)", "function", "λ", 3, 5)
+                    OutlineItem("sss", "constant", "c", 6, 6)
                 ]
                 @test o in os
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Atom, Test, JSON, Logging, CSTParser
+using Atom, Test, Atom.JSON, Logging, Atom.CSTParser
 
 
 joinpath′(files...) = Atom.fullpath(joinpath(files...))


### PR DESCRIPTION
~- introduce `@tojs` macro that enables us to easily construct `NamedTuple`s and `Dict`s~
~- no more verbose `todict` conversion~
~- bit of test robustness improvements~

internal refactors:
- use `NamedTuple` instead of `Dict` where possible: more robust for typo, etc
- no more verbose `todict` conversion
- a bit test improvement