### PR TITLE
bit refactors

### DIFF
--- a/src/datatip.jl
+++ b/src/datatip.jl
@@ -31,7 +31,7 @@ function datatip(word, mod, path, column = 1, row = 1, startrow = 0, context = "
 end
 
 datatip(dt::Vector{Dict{Symbol, Any}}) = Dict(:error => false, :strings => dt)
-datatip(dt::Int) = Dict(:error => false, :line => dt)
+datatip(dt::Integer) = Dict(:error => false, :line => dt)
 datatip(dt::Vector{Int}) = datatip(dt[1])
 
 function localdatatip(word, column, row, startrow, context)

--- a/src/display/base.jl
+++ b/src/display/base.jl
@@ -144,7 +144,7 @@ function trim(xs, len = 25)
   end
 end
 
-pluralize(n::Int, one, more=one) = string(n, " ", n == 1 ? one : more)
+pluralize(n::Integer, one, more=one) = string(n, " ", n == 1 ? one : more)
 pluralize(xs, one, more=one) = pluralize(length(xs), one, more)
 
 @render i::Inline xs::Vector begin

--- a/src/static/local.jl
+++ b/src/static/local.jl
@@ -72,7 +72,7 @@ function localbindings(expr, text, bindings = LocalBS[], pos = 1, line = 1)
         elseif iswhereclause(expr)
             for arg in expr
                 localbindings(arg, text, bindings, pos, line)
-                line += countlines(arg, text, pos)
+                line += counteols_in_expr(arg, text, pos)
                 pos += arg.fullspan
             end
         else
@@ -85,7 +85,7 @@ function localbindings(expr, text, bindings = LocalBS[], pos = 1, line = 1)
             children = LocalBS[]
             for arg in expr
                 localbindings(arg, text, children, pos, line)
-                line += countlines(arg, text, pos)
+                line += counteols_in_expr(arg, text, pos)
                 pos += arg.fullspan
             end
 
@@ -98,7 +98,7 @@ function localbindings(expr, text, bindings = LocalBS[], pos = 1, line = 1)
     # look for more local bindings if exists
     for arg in expr
         localbindings(arg, text, bindings, pos, line)
-        line += countlines(arg, text, pos)
+        line += counteols_in_expr(arg, text, pos)
         pos += arg.fullspan
     end
 

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -117,19 +117,19 @@ function str_value(x::EXPR)::String
 end
 
 """
-    str_value_verbatim(expr::EXPR, text::String, pos::Int)::String
+    str_value_verbatim(expr::EXPR, text::String, pos::Integer)::String
 
 _Extract_ a source code from `text` that corresponds to `expr` starting from `pos`.
 """
-function str_value_verbatim(expr::EXPR, text::String, pos::Int)::String
+function str_value_verbatim(expr::EXPR, text::String, pos::Integer)::String
     endpos = pos + expr.span
     n = ncodeunits(text)
     s = nextind(text, clamp(pos - 1, 0, n))
     e = prevind(text, clamp(endpos, 1, n + 1))
     return string(strip(text[s:e]))
 end
-str_value_verbatim(bind::Binding, text::String, pos::Int) = str_value_verbatim(bind.val, text, pos)
-str_value_verbatim(bind, text::String, pos::Int) = ""
+str_value_verbatim(bind::Binding, text::String, pos::Integer) = str_value_verbatim(bind.val, text, pos)
+str_value_verbatim(bind, text::String, pos::Integer) = ""
 
 # atom icon & types
 # -----------------

--- a/src/static/static.jl
+++ b/src/static/static.jl
@@ -64,7 +64,7 @@ isexport(expr::EXPR) = typof(expr) === CSTParser.Export
 # string utilities
 # ----------------
 
-function Base.countlines(expr::EXPR, text::String, pos::Int, full::Bool = true; eol = '\n')
+function counteols_in_expr(expr::EXPR, text::String, pos::Integer, full::Bool = true; eol = '\n')
     endpos = pos + (full ? expr.fullspan : expr.span)
     n = ncodeunits(text)
     s = nextind(text, clamp(pos - 1, 0, n))

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -59,11 +59,11 @@ function _toplevelitems(
         # binding
         bind = bindingof(expr)
         if bind !== nothing
-            lines = line:line+countlines(expr, text, pos, false)
+            lines = line:line+counteols_in_expr(expr, text, pos, false)
             push!(items, ToplevelBinding(expr, bind, lines))
         end
 
-        lines = line:line+countlines(expr, text, pos, false)
+        lines = line:line+counteols_in_expr(expr, text, pos, false)
 
         # destructure multiple returns
         if ismultiplereturn(expr)
@@ -92,7 +92,7 @@ function _toplevelitems(
         end
         for arg in expr
             _toplevelitems(text, arg, items, line, pos; mod = mod, inmod = inmod)
-            line += countlines(arg, text, pos)
+            line += counteols_in_expr(arg, text, pos)
             pos += arg.fullspan
         end
     end

--- a/src/static/toplevel.jl
+++ b/src/static/toplevel.jl
@@ -51,7 +51,7 @@ toplevelitems(text::String, expr::Nothing; kwargs...)::Vector{ToplevelItem} = To
 
 function _toplevelitems(
     text::String, expr::EXPR,
-    items::Vector{ToplevelItem} = ToplevelItem[], line::Int = 1, pos::Int = 1;
+    items::Vector{ToplevelItem} = ToplevelItem[], line::Integer = 1, pos::Integer = 1;
     mod::Union{Nothing, String} = nothing, inmod::Bool = false,
 )
     # add items if `mod` isn't specified or in a target modle

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -126,7 +126,7 @@ end
 # ---------------
 
 """
-    strlimit(str::AbstractString, limit::Int = 30, ellipsis::AbstractString = "…")
+    strlimit(str::AbstractString, limit::Integer = 30, ellipsis::AbstractString = "…")
 
 Chops off `str` so that its _length_ doesn't exceed `limit`. The excessive part
   will be replaced by `ellipsis`.
@@ -134,7 +134,7 @@ Chops off `str` so that its _length_ doesn't exceed `limit`. The excessive part
 !!! note
     The length of returned string will _never_ exceed `limit`.
 """
-function strlimit(str::AbstractString, limit::Int = 30, ellipsis::AbstractString = "…")
+function strlimit(str::AbstractString, limit::Integer = 30, ellipsis::AbstractString = "…")
   will_append = length(str) > limit
 
   io = IOBuffer()


### PR DESCRIPTION
- `::Int` -> `::Integer` for 32bits system compatibility
- don't overload `Base.contlines`