### PR TITLE
fix function display on v1.6

### DIFF
--- a/src/display/base.jl
+++ b/src/display/base.jl
@@ -103,16 +103,9 @@ import Base.Docs: doc
 isanon(f) = startswith(string(typeof(f).name.mt.name), "#")
 
 @render Inline f::Function begin
-  if ismacro(f)
-    name = string(f)
-  else
-    name = string(typeof(f).name)
-    inner = match(r"typeof\((.+)\)", name)
-    if inner ≠ nothing
-      name = inner[1]
-    end
-  end
-  binding = Docs.Binding(typeof(f).name.module, Symbol(name))
+  name = repr(f)
+  name_without_module = string(f)
+  binding = Docs.Binding(typeof(f).name.module, Symbol(name_without_module))
   if isanon(f)
     span(".syntax--support.syntax--function", "λ")
   else

--- a/test/display.jl
+++ b/test/display.jl
@@ -8,6 +8,27 @@
     @test Atom.render(Atom.Inline(), :abc)[:contents] == [":abc"]
     @test Atom.render(Atom.Inline(), Symbol("A B"))[:contents] == ["Symbol(\"A B\")"]
 
+    # function display
+    # basic
+    let d = Atom.render(Atom.Inline(), sin)
+        @test d[:type] === :lazy
+        @test d[:head][:contents] == ["sin"]
+    end
+
+    # in a specific module
+    m = eval(:(module $(gensym(:atomjltestmodule)) end))
+
+    let d = Atom.render(Atom.Inline(), Core.eval(m, :(mock_func() = nothing)))
+        @test d[:type] === :lazy
+        @test d[:head][:contents] == ["$(m).mock_func"]
+    end
+
+    # macro
+    let d = Atom.render(Atom.Inline(), Core.eval(m, :(macro mock_macro() end)))
+        @test d[:type] === :lazy
+        @test d[:head][:contents] == ["$(m).@mock_macro"]
+    end
+
     @test length(Atom.trim(rand(50), 20)) == 20
 
     @test Atom.isanon(sin) == false


### PR DESCRIPTION
I found `string(typeof(f).name)` returns `"typename(typeof(f))"`, which causes function display a bit weird (e.g. `sin(`) on v1.6 (at least current master)

I believe using `repr` and `string` would make the logic mach simpler and robust in the future, so this PR.

I also improved a logic in a completion a bit