### PR TITLE
Remove dependency WebSockets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,6 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
-WebSockets = "104b5d7c-a370-577a-8038-80a2059c5097"
 
 [compat]
 CSTParser = "=1.1.0, ^2"
@@ -56,7 +55,6 @@ Requires = "^0.5, 1.0"
 Traceur = "^0.3"
 TreeViews = "^0.3.0"
 WebIO = "^0.8.1"
-WebSockets = "^1.5"
 julia = "0.7, 1"
 
 [extras]

--- a/src/display/webio.jl
+++ b/src/display/webio.jl
@@ -1,6 +1,6 @@
 # TODO: this should be more robust, ideally.
 using Logging
-import WebIO, HTTP, WebSockets
+import WebIO, HTTP
 
 const pages = Dict{String,Any}()
 const server = Ref{Any}()


### PR DESCRIPTION
Can `WebSockets` be removed as a dependency?
Naively appears not to be used, and functionality seems to be replaced in `HTTP`?

`WebSockets` is preventing `HTTP` from upgrading to `v0.9`
